### PR TITLE
fix: disable SHA tags for non-main branches

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -65,7 +65,7 @@ jobs:
             type=semver,pattern=v{{major}},value=v${{ steps.package-version.outputs.version }}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
 
@@ -80,7 +80,7 @@ jobs:
             type=semver,pattern=v{{major}},value=v${{ steps.package-version.outputs.version }}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
 


### PR DESCRIPTION
Fixes invalid Docker tags like `-f6eb71d` that were being generated for tag pushes.