### PR TITLE
fix: disable Vite strict host checking for production

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -7,9 +7,19 @@ on:
       - dev
     tags:
       - "v*"
+    paths:
+      - "apps/api/**"
+      - "apps/web/**"
+      - "VERSION"
+      - ".github/workflows/build-and-push.yml"
   pull_request:
     branches:
       - main
+    paths:
+      - "apps/api/**"
+      - "apps/web/**"
+      - "VERSION"
+      - ".github/workflows/build-and-push.yml"
   workflow_dispatch:
     inputs:
       tag:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -44,5 +44,7 @@ USER 1000
 EXPOSE 3000
 
 # Run vite preview to serve the built static files
+# Note: allowedHosts is configured in vite.config.ts
+# For production, we disable strict host checking to allow any host (security handled by ingress/TLS)
 CMD ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "3000"]
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,12 +25,12 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
         configure: (proxy, _options) => {
-          proxy.on('proxyReq', (proxyReq, req, _res) => {
+          proxy.on("proxyReq", (proxyReq, req, _res) => {
             // Add trailing slash to paths that need it (FastAPI routes)
-            const url = req.url || '';
+            const url = req.url || "";
             if (url.match(/^\/(schedule|facilities)(\?.*)?$/)) {
-              const [path, query] = url.split('?');
-              proxyReq.path = path + '/' + (query ? '?' + query : '');
+              const [path, query] = url.split("?");
+              proxyReq.path = path + "/" + (query ? "?" + query : "");
             }
           });
         },
@@ -41,6 +41,14 @@ export default defineConfig({
     host: true,
     port: 3000,
     strictPort: false,
-    allowedHosts: ["swimto.eldertree.local", "swimto.local", "localhost"],
+    // Disable strict host checking for production (behind reverse proxy/ingress)
+    // Security is handled by Kubernetes ingress/TLS, not by Vite
+    strictHost: false,
+    allowedHosts: [
+      "swimto.eldertree.local",
+      "swimto.eldertree.xyz",
+      "swimto.local",
+      "localhost",
+    ],
   },
 });


### PR DESCRIPTION
Fixes 'host not allowed' error for swimto.eldertree.xyz

- Set strictHost: false in vite.config.ts preview config
- Optimize GitHub Actions to only build on relevant file changes
- Security is handled by Kubernetes ingress and TLS