### PR TITLE
Fix Google auth URL timeout: reduce timeout and add retry logic

### DIFF
--- a/apps/api/app/routes/auth.py
+++ b/apps/api/app/routes/auth.py
@@ -16,7 +16,10 @@ router = APIRouter()
 @router.get("/auth/google-url", tags=["auth"])
 async def get_google_auth_url():
     """Get Google OAuth URL."""
+    logger.debug("Received request for Google auth URL")
+    
     if not settings.google_client_id:
+        logger.warning("Google OAuth not configured - missing client_id")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Google OAuth not configured"
@@ -34,6 +37,7 @@ async def get_google_auth_url():
         f"&prompt=consent"
     )
     
+    logger.debug(f"Generated Google auth URL (redirect_uri: {redirect_uri})")
     return {"auth_url": google_auth_url}
 
 

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -90,17 +90,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       let errorMessage =
         errorInfo.message || "Failed to initiate login. Please try again.";
 
-      // Check if it's a network error
+      // Check if it's a timeout error (most common issue)
       if (
+        axios.isAxiosError(error) &&
+        (error.code === "ECONNABORTED" || error.message.includes("timeout"))
+      ) {
+        errorMessage =
+          "The authentication server took too long to respond. This may indicate a network issue or the server is temporarily unavailable. Please check your connection and try again.";
+      }
+      // Check if it's a network error
+      else if (
         errorInfo.title === "Network Connection Failed" ||
-        errorInfo.title === "Server Unavailable"
+        errorInfo.title === "Server Unavailable" ||
+        errorInfo.title === "Request Timed Out"
       ) {
         errorMessage =
           "Unable to connect to the authentication server. Please check your connection and try again.";
       }
-
       // Check if OAuth is not configured
-      if (axios.isAxiosError(error) && error.response?.status === 503) {
+      else if (axios.isAxiosError(error) && error.response?.status === 503) {
         errorMessage =
           "Google authentication is not configured on the server. Please contact support.";
       }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -112,8 +112,37 @@ export interface FavoriteResponse {
 
 export const authApi = {
   getGoogleAuthUrl: async (): Promise<{ auth_url: string }> => {
-    const { data } = await api.get("/auth/google-url");
-    return data;
+    // Use a shorter timeout for this endpoint since it should return instantly
+    // Retry logic for network issues
+    const maxRetries = 2;
+    let lastError: unknown;
+    
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const { data } = await api.get("/auth/google-url", {
+          timeout: 10000, // 10 seconds - should be instant, but allow some buffer
+        });
+        return data;
+      } catch (error) {
+        lastError = error;
+        
+        // Don't retry on 4xx errors (client errors)
+        if (axios.isAxiosError(error) && error.response?.status && error.response.status < 500) {
+          throw error;
+        }
+        
+        // On last attempt, throw the error
+        if (attempt === maxRetries) {
+          throw error;
+        }
+        
+        // Wait before retrying (exponential backoff)
+        await new Promise(resolve => setTimeout(resolve, 1000 * (attempt + 1)));
+      }
+    }
+    
+    // Should never reach here, but TypeScript needs this
+    throw lastError;
   },
 
   googleCallback: async (code: string): Promise<TokenResponse> => {


### PR DESCRIPTION
Fixes the timeout issue with the Google auth URL endpoint:

- Reduce timeout from 30s to 10s for /auth/google-url endpoint (should be instant)
- Add retry logic (2 retries with exponential backoff) for network issues
- Improve error handling for timeout errors with better user feedback
- Add backend logging for debugging

This addresses the issue where requests to https://swimto.eldertree.xyz/api/auth/google-url were timing out after 30 seconds.