### PR TITLE
fix: Add middleware definitions and improve ingress configuration

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,4 +1,26 @@
 ---
+# Middleware for API path rewriting (removes /api prefix)
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: api-path-rewrite
+  namespace: swimto
+spec:
+  replacePathRegex:
+    regex: "^/api(/.*?)/?$"
+    replacement: "$1/"
+---
+# Middleware for HTTPS redirect
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+  namespace: swimto
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
 # Local domain Ingress (swimto.eldertree.local)
 # ExternalDNS annotation ensures DNS record is created in Pi-hole via RFC2136
 apiVersion: networking.k8s.io/v1
@@ -8,7 +30,7 @@ metadata:
   namespace: swimto
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: swimto-redirect-https@kubernetescrd,swimto-api-path-rewrite@kubernetescrd
     cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
     external-dns.alpha.kubernetes.io/hostname: swimto.eldertree.local
   labels:
@@ -48,6 +70,7 @@ metadata:
   namespace: swimto
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.middlewares: swimto-api-path-rewrite@kubernetescrd
     external-dns.alpha.kubernetes.io/hostname: swimto.eldertree.xyz
   labels:
     app: swimto


### PR DESCRIPTION
- Add api-path-rewrite middleware for proper API routing
- Add redirect-https middleware for local domain
- Update middleware references to use namespace-specific format
- Ensure both swimto.eldertree.local and swimto.eldertree.xyz are properly configured
- Add ExternalDNS annotations for automatic DNS record creation