### PR TITLE
fix(ci): add GHCR login before image verification

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -78,6 +78,13 @@ jobs:
       api_exists: ${{ steps.check-api.outputs.exists }}
       web_exists: ${{ steps.check-web.outputs.exists }}
     steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
       - name: Check API image exists
         id: check-api
         run: |
@@ -89,8 +96,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "❌ API image not found: $IMAGE"
           fi
-        env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
 
       - name: Check Web image exists
         id: check-web
@@ -103,8 +108,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "❌ Web image not found: $IMAGE"
           fi
-        env:
-          DOCKER_CLI_EXPERIMENTAL: enabled
 
   deploy-api:
     needs: [get-version, verify-images]


### PR DESCRIPTION
## Problem

The deployment workflow's `verify-images` job was failing because `docker manifest inspect` requires authentication to access GHCR images.

## Solution

Added GHCR login step using the existing `CR_PAT` secret before checking if images exist.

## Testing

Re-run the deployment workflow after merging to verify the fix.