### PR TITLE
fix(ci): use -F flag for client_payload JSON object

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -121,7 +121,7 @@ jobs:
           echo "Triggering deployment for swimto-api:${{ needs.get-version.outputs.image_tag }}"
           gh api repos/raolivei/pi-fleet/dispatches \
             -f event_type=deploy-image \
-            -f "client_payload={\"project\":\"swimto\",\"component\":\"api\",\"image_tag\":\"${{ needs.get-version.outputs.image_tag }}\"}"
+            -F client_payload='{"project":"swimto","component":"api","image_tag":"${{ needs.get-version.outputs.image_tag }}"}'
         env:
           GH_TOKEN: ${{ secrets.PI_FLEET_PAT }}
 
@@ -142,7 +142,7 @@ jobs:
           echo "Triggering deployment for swimto-web:${{ needs.get-version.outputs.image_tag }}"
           gh api repos/raolivei/pi-fleet/dispatches \
             -f event_type=deploy-image \
-            -f "client_payload={\"project\":\"swimto\",\"component\":\"web\",\"image_tag\":\"${{ needs.get-version.outputs.image_tag }}\"}"
+            -F client_payload='{"project":"swimto","component":"web","image_tag":"${{ needs.get-version.outputs.image_tag }}"}'
         env:
           GH_TOKEN: ${{ secrets.PI_FLEET_PAT }}
 


### PR DESCRIPTION
## Problem
The `gh api` command was treating `client_payload` as a string (`-f` flag) instead of a JSON object (`-F` flag), causing HTTP 422 errors:

```
For 'properties/client_payload', "{...}" is not an object.
```

This prevented the `repository_dispatch` from triggering pi-fleet deployments after successful builds.

## Fix
Changed `-f "client_payload=..."` to `-F client_payload='...'` which correctly parses the value as JSON.

## Testing
After merge, trigger a manual deployment via workflow_dispatch to verify.