### PR TITLE
fix(ci): use native ARM64 runners instead of QEMU

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -95,9 +95,9 @@ jobs:
 
   build-api:
     name: Build and Push API Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU needed
     needs: prepare
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
@@ -116,18 +116,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU for ARM64 emulation
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Build and push API image
         id: build-api
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./apps/api/Dockerfile
-          # eldertree cluster is ARM64 only - no need for multi-platform
           platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ needs.prepare.outputs.api-tags }}
@@ -144,9 +138,9 @@ jobs:
 
   build-web:
     name: Build and Push Web Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm  # Native ARM64 runner - no QEMU needed
     needs: prepare
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
@@ -162,11 +156,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Set up QEMU for ARM64 emulation
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -176,7 +165,6 @@ jobs:
         with:
           context: ./apps/web
           file: ./apps/web/Dockerfile
-          # eldertree cluster is ARM64 only - no need for multi-platform
           platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ needs.prepare.outputs.web-tags }}


### PR DESCRIPTION
## Problem
Web builds were taking >10 minutes and failing with:
```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

This happened because x86 runners (ubuntu-latest) were using QEMU to emulate ARM64, which is slow and unstable for complex builds like npm ci.

## Fix
- Switch from `ubuntu-latest` + QEMU to `ubuntu-24.04-arm` (native ARM64 runners)
- Remove `setup-qemu-action` steps (not needed on native ARM64)
- Reduce timeout from 30min to 15min (native builds are much faster)

## Expected Results
- Build time: ~10-15min → ~3-5min
- No more QEMU-related crashes
- More reliable builds