### PR TITLE
fix(ci): use heredoc for repository_dispatch JSON payload

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -119,9 +119,16 @@ jobs:
       - name: Trigger pi-fleet deployment for API
         run: |
           echo "Triggering deployment for swimto-api:${{ needs.get-version.outputs.image_tag }}"
-          gh api repos/raolivei/pi-fleet/dispatches \
-            -f event_type=deploy-image \
-            -F client_payload='{"project":"swimto","component":"api","image_tag":"${{ needs.get-version.outputs.image_tag }}"}'
+          gh api repos/raolivei/pi-fleet/dispatches --method POST --input - <<EOF
+          {
+            "event_type": "deploy-image",
+            "client_payload": {
+              "project": "swimto",
+              "component": "api",
+              "image_tag": "${{ needs.get-version.outputs.image_tag }}"
+            }
+          }
+          EOF
         env:
           GH_TOKEN: ${{ secrets.PI_FLEET_PAT }}
 
@@ -140,9 +147,16 @@ jobs:
       - name: Trigger pi-fleet deployment for Web
         run: |
           echo "Triggering deployment for swimto-web:${{ needs.get-version.outputs.image_tag }}"
-          gh api repos/raolivei/pi-fleet/dispatches \
-            -f event_type=deploy-image \
-            -F client_payload='{"project":"swimto","component":"web","image_tag":"${{ needs.get-version.outputs.image_tag }}"}'
+          gh api repos/raolivei/pi-fleet/dispatches --method POST --input - <<EOF
+          {
+            "event_type": "deploy-image",
+            "client_payload": {
+              "project": "swimto",
+              "component": "web",
+              "image_tag": "${{ needs.get-version.outputs.image_tag }}"
+            }
+          }
+          EOF
         env:
           GH_TOKEN: ${{ secrets.PI_FLEET_PAT }}
 


### PR DESCRIPTION
## Problem
The `-F` flag with shell quoting was still treating `client_payload` as a string, causing:
```
For 'properties/client_payload', "{...}" is not an object. (HTTP 422)
```

## Fix
Use heredoc (`--input -`) to pass the JSON body directly without shell quoting interference:
```bash
gh api repos/raolivei/pi-fleet/dispatches --method POST --input - <<EOF
{
  "event_type": "deploy-image",
  "client_payload": { ... }
}
EOF
```

## Testing
After merge, manually trigger deployment to verify.