### PR TITLE
chore: ignore monitoring.yaml stub file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ data/cache/
 charts/*/charts/
 *.tgz
 
+monitoring.yaml


### PR DESCRIPTION
Add monitoring.yaml to .gitignore - it's an unused stub file.