### PR TITLE
fix(web): remove unused Clock import that caused build failure

### DIFF
--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -25,7 +25,6 @@ import {
   Navigation,
   Star,
   Waves,
-  Clock,
   Timer,
 } from "lucide-react";
 import type { SwimType, Session } from "../types";


### PR DESCRIPTION
Removes unused Clock import from lucide-react in ScheduleView.tsx.

This was causing the build to fail with:
```
error TS6133: 'Clock' is declared but its value is never read.
```

We're using Timer instead, so Clock can be safely removed.