### PR TITLE
chore(k8s): update deployments to v0.5.4

### DIFF
--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: api
-          image: ghcr.io/raolivei/swimto-api:v0.5.2
+          image: ghcr.io/raolivei/swimto-api:v0.5.4
           imagePullPolicy: IfNotPresent # Use IfNotPresent for versioned tags
           command: ["sh", "-c"]
           args:

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: swimto-web
       annotations:
-        deployment.kubernetes.io/revision: "2025-11-25-v0.5.1"
+        deployment.kubernetes.io/revision: "2026-01-16-v0.5.4"
     spec:
       imagePullSecrets:
         - name: ghcr-secret
@@ -25,7 +25,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: web
-          image: ghcr.io/raolivei/swimto-web:v0.5.1 # {"$imagepolicy": "swimto:swimto-web-policy"}
+          image: ghcr.io/raolivei/swimto-web:v0.5.4 # {"$imagepolicy": "swimto:swimto-web-policy"}
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
Updates k8s deployments to use v0.5.4 images with mobile UI fixes.

Changes:
- api-deployment.yaml: ghcr.io/raolivei/swimto-api:v0.5.4
- web-deployment.yaml: ghcr.io/raolivei/swimto-web:v0.5.4

Already deployed to eldertree and verified working at:
- https://swimto.eldertree.local
- https://swimto.eldertree.xyz