### PR TITLE
fix(web): show session times prominently in mobile list view

### DIFF
--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -896,7 +896,11 @@ export default function ScheduleView() {
                                 />
                               </button>
                               <div className="flex-1">
-                                <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-1 text-lg">
+                                {/* Time - Most important info, shown prominently */}
+                                <div className="text-xl font-bold text-primary-600 dark:text-primary-400 mb-2">
+                                  {formatTimeRange(session.start_time, session.end_time)}
+                                </div>
+                                <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-1 text-base">
                                   {session.facility?.website ? (
                                     <a
                                       href={session.facility.website}


### PR DESCRIPTION
## Critical Fix

The session time was completely missing from the list view cards on mobile. This is the most important information for users - the whole point of the app is to show when swim sessions are scheduled!

### Changes
- Added time display as the first element in session cards
- Time shown in large, primary-colored text (xl font, primary-600)
- Slightly reduced facility name size to create visual hierarchy
- Time uses `formatTimeRange()` for consistent formatting (e.g., '7:00 AM - 8:30 AM')

### Before
- Facility name
- Distance
- Address
- Swim type badge

### After  
- **Session time** (prominent, large text)
- Facility name
- Distance
- Address
- Swim type badge

This ensures users can immediately see when swim sessions are scheduled.