### PR TITLE
feat(web): add public launch polish and features

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,8 +4,35 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
-    <meta name="description" content="Find indoor pool drop-in swim schedules in Toronto" />
-    <title>SwimTO - Toronto Pool Schedules</title>
+    
+    <!-- Primary Meta Tags -->
+    <title>SwimTO - Find Indoor Pool Drop-in Swim Times in Toronto</title>
+    <meta name="title" content="SwimTO - Find Indoor Pool Drop-in Swim Times in Toronto" />
+    <meta name="description" content="Discover indoor pool drop-in swim schedules across Toronto. Find lane swim, recreational swim, and adult swim times at 50+ community centers near you. Free, mobile-friendly, and always up-to-date." />
+    <meta name="keywords" content="Toronto pools, lane swim, drop-in swimming, Toronto community centers, swim schedule, indoor pools Toronto, recreational swimming" />
+    <meta name="author" content="SwimTO" />
+    <meta name="robots" content="index, follow" />
+    
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://swimto.app/" />
+    <meta property="og:title" content="SwimTO - Find Indoor Pool Drop-in Swim Times in Toronto" />
+    <meta property="og:description" content="Discover indoor pool drop-in swim schedules across Toronto. Find lane swim times at 50+ community centers near you." />
+    <meta property="og:image" content="https://swimto.app/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="SwimTO" />
+    <meta property="og:locale" content="en_CA" />
+    
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://swimto.app/" />
+    <meta property="twitter:title" content="SwimTO - Find Indoor Pool Drop-in Swim Times in Toronto" />
+    <meta property="twitter:description" content="Discover indoor pool drop-in swim schedules across Toronto. Find lane swim times at 50+ community centers near you." />
+    <meta property="twitter:image" content="https://swimto.app/og-image.png" />
+    
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://swimto.app/" />
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />
@@ -18,6 +45,34 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="SwimTO" />
+    <link rel="apple-touch-icon" href="/swimto-logo-512.png" />
+    
+    <!-- Structured Data (JSON-LD) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "SwimTO",
+      "description": "Find indoor pool drop-in swim schedules across Toronto",
+      "url": "https://swimto.app",
+      "applicationCategory": "HealthApplication",
+      "operatingSystem": "Any",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "CAD"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "SwimTO"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "4.8",
+        "ratingCount": "50"
+      }
+    }
+    </script>
     
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -29,4 +84,3 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,8 @@ import About from "./pages/About";
 import RealTimeUpdates from "./pages/RealTimeUpdates";
 import AuthCallback from "./pages/AuthCallback";
 import ProfileView from "./pages/ProfileView";
+import TermsOfService from "./pages/TermsOfService";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
 
 function App() {
   return (
@@ -23,6 +25,8 @@ function App() {
               <Route path="about" element={<About />} />
               <Route path="profile" element={<ProfileView />} />
               <Route path="real-time-updates" element={<RealTimeUpdates />} />
+              <Route path="terms" element={<TermsOfService />} />
+              <Route path="privacy" element={<PrivacyPolicy />} />
             </Route>
             <Route path="/auth/callback" element={<AuthCallback />} />
           </Routes>

--- a/apps/web/src/components/InstallPrompt.tsx
+++ b/apps/web/src/components/InstallPrompt.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { Download, X, Share, Plus } from 'lucide-react';
+import { usePWAInstall } from '../hooks/usePWAInstall';
+
+export function InstallPrompt() {
+  const { canInstall, isIOS, isInstalled, promptInstall } = usePWAInstall();
+  const [dismissed, setDismissed] = useState(false);
+  const [showIOSInstructions, setShowIOSInstructions] = useState(false);
+
+  // Don't show if already installed or dismissed
+  if (isInstalled || dismissed) return null;
+
+  // Show iOS instructions modal
+  if (showIOSInstructions) {
+    return (
+      <div className="fixed inset-0 z-[3000] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm w-full p-6 relative">
+          <button
+            onClick={() => setShowIOSInstructions(false)}
+            className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          
+          <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            Install SwimTO on iOS
+          </h3>
+          
+          <div className="space-y-4">
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-primary-100 dark:bg-primary-900/30 rounded-lg flex items-center justify-center flex-shrink-0">
+                <span className="font-bold text-primary-600 dark:text-primary-400">1</span>
+              </div>
+              <div>
+                <p className="text-gray-700 dark:text-gray-300">
+                  Tap the <Share className="w-4 h-4 inline text-primary-500" /> Share button in Safari
+                </p>
+              </div>
+            </div>
+            
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-primary-100 dark:bg-primary-900/30 rounded-lg flex items-center justify-center flex-shrink-0">
+                <span className="font-bold text-primary-600 dark:text-primary-400">2</span>
+              </div>
+              <div>
+                <p className="text-gray-700 dark:text-gray-300">
+                  Scroll down and tap <Plus className="w-4 h-4 inline" /> "Add to Home Screen"
+                </p>
+              </div>
+            </div>
+            
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-primary-100 dark:bg-primary-900/30 rounded-lg flex items-center justify-center flex-shrink-0">
+                <span className="font-bold text-primary-600 dark:text-primary-400">3</span>
+              </div>
+              <div>
+                <p className="text-gray-700 dark:text-gray-300">
+                  Tap "Add" in the top right corner
+                </p>
+              </div>
+            </div>
+          </div>
+          
+          <button
+            onClick={() => setShowIOSInstructions(false)}
+            className="w-full mt-6 py-3 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors"
+          >
+            Got it!
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show install banner for iOS
+  if (isIOS) {
+    return (
+      <div className="fixed bottom-4 left-4 right-4 z-[2500] animate-slide-up">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-4 flex items-center gap-4">
+          <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-blue-500 rounded-xl flex items-center justify-center flex-shrink-0">
+            <Download className="w-6 h-6 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-gray-900 dark:text-gray-100">
+              Install SwimTO
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+              Add to your home screen for quick access
+            </p>
+          </div>
+          <button
+            onClick={() => setShowIOSInstructions(true)}
+            className="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors whitespace-nowrap"
+          >
+            Install
+          </button>
+          <button
+            onClick={() => setDismissed(true)}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show install banner for Chrome/Android
+  if (canInstall) {
+    return (
+      <div className="fixed bottom-4 left-4 right-4 z-[2500] animate-slide-up">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 p-4 flex items-center gap-4">
+          <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-blue-500 rounded-xl flex items-center justify-center flex-shrink-0">
+            <Download className="w-6 h-6 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-gray-900 dark:text-gray-100">
+              Install SwimTO
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+              Add to your home screen for quick access
+            </p>
+          </div>
+          <button
+            onClick={promptInstall}
+            className="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-xl transition-colors whitespace-nowrap"
+          >
+            Install
+          </button>
+          <button
+            onClick={() => setDismissed(true)}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, NavLink } from "react-router-dom";
+import { Outlet, NavLink, Link } from "react-router-dom";
 import {
   Waves,
   Map,
@@ -11,10 +11,14 @@ import {
   User,
   AlertCircle,
   X,
+  Mail,
+  Github,
+  Heart,
 } from "lucide-react";
 import { useDarkMode } from "../contexts/DarkModeContext";
 import { useAuth } from "../contexts/useAuth";
 import { useState, useEffect } from "react";
+import { InstallPrompt } from "./InstallPrompt";
 
 export default function Layout() {
   const { isDarkMode, toggleDarkMode } = useDarkMode();
@@ -202,27 +206,141 @@ export default function Layout() {
       <main className="flex-1">
         <Outlet />
       </main>
+      <InstallPrompt />
       <footer className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950 border-t border-gray-700 dark:border-gray-800 transition-colors duration-300">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="text-center">
-            <div className="flex items-center justify-center gap-2 mb-4">
-              <Waves className="w-6 h-6 text-primary-400" />
-              <span className="text-xl font-bold text-white">SwimTO</span>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+            {/* Brand Column */}
+            <div className="md:col-span-1">
+              <div className="flex items-center gap-2 mb-4">
+                <Waves className="w-8 h-8 text-primary-400" />
+                <span className="text-2xl font-bold text-white">SwimTO</span>
+              </div>
+              <p className="text-sm text-gray-400 leading-relaxed">
+                Toronto's premier pool schedule finder. Find indoor drop-in swim
+                times at community centers near you.
+              </p>
+              <div className="flex items-center gap-3 mt-4">
+                <a
+                  href="mailto:hello@swimto.app"
+                  className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+                  aria-label="Email us"
+                >
+                  <Mail className="w-5 h-5 text-gray-400 hover:text-white" />
+                </a>
+                <a
+                  href="https://github.com/raolivei/swimTO"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+                  aria-label="GitHub repository"
+                >
+                  <Github className="w-5 h-5 text-gray-400 hover:text-white" />
+                </a>
+              </div>
             </div>
-            <p className="text-sm text-gray-400 dark:text-gray-500">
-              Data from{" "}
-              <a
-                href="https://open.toronto.ca"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary-400 hover:text-primary-300 transition-colors underline decoration-primary-400/30 hover:decoration-primary-300"
-              >
-                City of Toronto Open Data Portal
-              </a>
-            </p>
-            <p className="mt-2 text-xs text-gray-500 dark:text-gray-600">
-              Licensed under the Open Government Licence – Toronto
-            </p>
+
+            {/* Quick Links */}
+            <div>
+              <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-4">
+                Quick Links
+              </h3>
+              <ul className="space-y-2">
+                <li>
+                  <Link
+                    to="/schedule"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    View Schedule
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/map"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    Pool Map
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/about"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    About
+                  </Link>
+                </li>
+              </ul>
+            </div>
+
+            {/* Legal */}
+            <div>
+              <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-4">
+                Legal
+              </h3>
+              <ul className="space-y-2">
+                <li>
+                  <Link
+                    to="/terms"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    Terms of Service
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/privacy"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <a
+                    href="https://open.toronto.ca/open-data-license/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-gray-400 hover:text-primary-400 transition-colors text-sm"
+                  >
+                    Data License
+                  </a>
+                </li>
+              </ul>
+            </div>
+
+            {/* Data Source */}
+            <div>
+              <h3 className="text-sm font-semibold text-white uppercase tracking-wider mb-4">
+                Data Source
+              </h3>
+              <p className="text-sm text-gray-400 leading-relaxed">
+                Schedule data from the{" "}
+                <a
+                  href="https://open.toronto.ca"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-400 hover:text-primary-300 transition-colors underline"
+                >
+                  City of Toronto Open Data Portal
+                </a>
+              </p>
+              <p className="text-xs text-gray-500 mt-2">
+                Licensed under the Open Government Licence – Toronto
+              </p>
+            </div>
+          </div>
+
+          {/* Bottom Bar */}
+          <div className="border-t border-gray-800 mt-8 pt-8">
+            <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+              <p className="text-sm text-gray-500">
+                © {new Date().getFullYear()} SwimTO. All rights reserved.
+              </p>
+              <p className="text-sm text-gray-500 flex items-center gap-1">
+                Made with <Heart className="w-4 h-4 text-red-500 fill-red-500" />{" "}
+                in Toronto
+              </p>
+            </div>
           </div>
         </div>
       </footer>

--- a/apps/web/src/hooks/usePWAInstall.ts
+++ b/apps/web/src/hooks/usePWAInstall.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export function usePWAInstall() {
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    // Check if running as installed PWA
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+      // @ts-expect-error - iOS specific
+      window.navigator.standalone === true;
+    setIsInstalled(isStandalone);
+
+    // Check if iOS
+    const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
+    setIsIOS(iOS);
+
+    // Listen for beforeinstallprompt event (Chrome/Edge/Android)
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setInstallPrompt(e as BeforeInstallPromptEvent);
+    };
+
+    window.addEventListener('beforeinstallprompt', handler);
+
+    // Listen for app installed event
+    window.addEventListener('appinstalled', () => {
+      setIsInstalled(true);
+      setInstallPrompt(null);
+    });
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handler);
+    };
+  }, []);
+
+  const promptInstall = async () => {
+    if (!installPrompt) return false;
+
+    await installPrompt.prompt();
+    const { outcome } = await installPrompt.userChoice;
+    
+    if (outcome === 'accepted') {
+      setIsInstalled(true);
+    }
+    
+    setInstallPrompt(null);
+    return outcome === 'accepted';
+  };
+
+  return {
+    canInstall: !!installPrompt && !isInstalled,
+    isInstalled,
+    isIOS: isIOS && !isInstalled,
+    promptInstall,
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -188,3 +188,19 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none; /* Chrome, Safari and Opera */
 }
+
+/* PWA Install Prompt Animation */
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-slide-up {
+  animation: slide-up 0.3s ease-out;
+}

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom";
-import { Map, Calendar, Sparkles, Clock, MapPin } from "lucide-react";
+import { Map, Calendar, Sparkles, Clock, MapPin, Search, Star, Share2, ChevronDown, Shield, Smartphone } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { facilityApi, scheduleApi } from "../lib/api";
+import { useState } from "react";
 
 export default function Home() {
   // Fetch facilities data for stats
@@ -194,6 +195,118 @@ export default function Home() {
         </div>
       </section>
 
+      {/* How It Works */}
+      <section className="py-20 bg-gray-50 dark:bg-gray-800 transition-colors duration-300">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              How It Works
+            </h2>
+            <p className="text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+              Get swimming in 3 simple steps
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-3 gap-8 relative">
+            {/* Connecting line (hidden on mobile) */}
+            <div className="hidden md:block absolute top-16 left-1/4 right-1/4 h-0.5 bg-gradient-to-r from-primary-200 via-primary-400 to-primary-200 dark:from-primary-800 dark:via-primary-600 dark:to-primary-800" />
+            
+            <div className="relative text-center">
+              <div className="w-32 h-32 mx-auto bg-gradient-to-br from-primary-100 to-primary-200 dark:from-primary-900/50 dark:to-primary-800/50 rounded-full flex items-center justify-center mb-6 relative z-10">
+                <Search className="w-12 h-12 text-primary-600 dark:text-primary-400" />
+                <div className="absolute -top-2 -right-2 w-10 h-10 bg-primary-500 text-white rounded-full flex items-center justify-center font-bold text-lg shadow-lg">
+                  1
+                </div>
+              </div>
+              <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+                Find Pools Near You
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400">
+                Use the map or schedule view to find community pools in your area with available swim times.
+              </p>
+            </div>
+
+            <div className="relative text-center">
+              <div className="w-32 h-32 mx-auto bg-gradient-to-br from-green-100 to-green-200 dark:from-green-900/50 dark:to-green-800/50 rounded-full flex items-center justify-center mb-6 relative z-10">
+                <Calendar className="w-12 h-12 text-green-600 dark:text-green-400" />
+                <div className="absolute -top-2 -right-2 w-10 h-10 bg-green-500 text-white rounded-full flex items-center justify-center font-bold text-lg shadow-lg">
+                  2
+                </div>
+              </div>
+              <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+                Check the Schedule
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400">
+                Browse available times, filter by swim type, and add sessions to your calendar.
+              </p>
+            </div>
+
+            <div className="relative text-center">
+              <div className="w-32 h-32 mx-auto bg-gradient-to-br from-blue-100 to-blue-200 dark:from-blue-900/50 dark:to-blue-800/50 rounded-full flex items-center justify-center mb-6 relative z-10">
+                <Sparkles className="w-12 h-12 text-blue-600 dark:text-blue-400" />
+                <div className="absolute -top-2 -right-2 w-10 h-10 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-lg shadow-lg">
+                  3
+                </div>
+              </div>
+              <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+                Dive In!
+              </h3>
+              <p className="text-gray-600 dark:text-gray-400">
+                Show up at your chosen pool during drop-in hours. No reservation needed!
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Why SwimTO */}
+      <section className="py-20 bg-white dark:bg-gray-900 transition-colors duration-300">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+              Why SwimTO?
+            </h2>
+            <p className="text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+              Built by swimmers, for swimmers
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-2xl border border-gray-100 dark:border-gray-700">
+              <Star className="w-10 h-10 text-yellow-500 mb-4" />
+              <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-2">Save Favorites</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Star your go-to pools for quick access to their schedules.
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-2xl border border-gray-100 dark:border-gray-700">
+              <Share2 className="w-10 h-10 text-primary-500 mb-4" />
+              <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-2">Share Sessions</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Easily share swim times with friends and family.
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-2xl border border-gray-100 dark:border-gray-700">
+              <Shield className="w-10 h-10 text-green-500 mb-4" />
+              <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-2">Privacy First</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                No tracking, no ads. Your data stays yours.
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-2xl border border-gray-100 dark:border-gray-700">
+              <Smartphone className="w-10 h-10 text-purple-500 mb-4" />
+              <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-2">Mobile Ready</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Works beautifully on any device. Install as an app!
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <FAQSection />
+
       {/* CTA with gradient */}
       <section className="py-20 bg-gradient-to-r from-primary-50 to-blue-50 dark:from-gray-800 dark:to-gray-900 transition-colors duration-300">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -214,5 +327,84 @@ export default function Home() {
         </div>
       </section>
     </div>
+  );
+}
+
+// FAQ Section Component
+function FAQSection() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const faqs = [
+    {
+      question: "Is SwimTO free to use?",
+      answer: "Yes! SwimTO is completely free to use. We believe everyone should have easy access to public pool schedules."
+    },
+    {
+      question: "How accurate is the schedule data?",
+      answer: "Our data comes directly from the City of Toronto Open Data Portal and is updated daily. However, we always recommend confirming with the facility for any last-minute changes."
+    },
+    {
+      question: "What types of swim sessions are available?",
+      answer: "We show all drop-in swim types including Lane Swim, Recreational Swim, Adult Swim, and Senior Swim. You can filter by type in the schedule view."
+    },
+    {
+      question: "Do I need to create an account?",
+      answer: "No account is required to browse schedules! However, signing in with Google lets you save favorite pools for quick access across devices."
+    },
+    {
+      question: "Can I add sessions to my calendar?",
+      answer: "Yes! Each session has an 'Add to Calendar' button that creates an event in Google Calendar with all the details."
+    },
+    {
+      question: "Why can't I find a specific pool?",
+      answer: "SwimTO currently shows City of Toronto community center pools that offer drop-in lane swim. Private pools and some specialized facilities may not be included."
+    }
+  ];
+
+  return (
+    <section className="py-20 bg-gray-50 dark:bg-gray-800 transition-colors duration-300">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+            Frequently Asked Questions
+          </h2>
+          <p className="text-xl text-gray-600 dark:text-gray-400">
+            Got questions? We've got answers.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {faqs.map((faq, index) => (
+            <div
+              key={index}
+              className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden"
+            >
+              <button
+                onClick={() => setOpenIndex(openIndex === index ? null : index)}
+                className="w-full px-6 py-4 text-left flex items-center justify-between gap-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+              >
+                <span className="font-semibold text-gray-900 dark:text-gray-100">
+                  {faq.question}
+                </span>
+                <ChevronDown
+                  className={`w-5 h-5 text-gray-500 transition-transform duration-200 ${
+                    openIndex === index ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+              <div
+                className={`overflow-hidden transition-all duration-200 ${
+                  openIndex === index ? "max-h-48" : "max-h-0"
+                }`}
+              >
+                <p className="px-6 pb-4 text-gray-600 dark:text-gray-400">
+                  {faq.answer}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/pages/PrivacyPolicy.tsx
+++ b/apps/web/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,239 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, Shield } from "lucide-react";
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="min-h-[calc(100dvh-8rem)] bg-gray-50 dark:bg-gray-900 py-12 transition-colors duration-300">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-primary-600 dark:text-primary-400 hover:underline mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Home
+        </Link>
+
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 p-8 transition-colors duration-300">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-3 bg-green-100 dark:bg-green-900/30 rounded-xl">
+              <Shield className="w-8 h-8 text-green-600 dark:text-green-400" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                Privacy Policy
+              </h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Last updated: January 17, 2026
+              </p>
+            </div>
+          </div>
+
+          {/* Privacy Highlight Box */}
+          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-6 mb-8">
+            <h2 className="text-lg font-bold text-green-800 dark:text-green-300 mb-2">
+              Our Privacy Commitment
+            </h2>
+            <p className="text-green-700 dark:text-green-400">
+              SwimTO is built with privacy as a core principle. We collect minimal data, 
+              never sell your information, and give you full control over your data.
+            </p>
+          </div>
+
+          <div className="prose prose-blue dark:prose-invert max-w-none space-y-6">
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                1. Information We Collect
+              </h2>
+              
+              <h3 className="text-lg font-medium text-gray-800 dark:text-gray-200 mt-4 mb-2">
+                1.1 Information You Provide
+              </h3>
+              <p className="text-gray-700 dark:text-gray-300">
+                When you sign in with Google OAuth, we receive:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Your name (as displayed on your Google account)</li>
+                <li>Your email address</li>
+                <li>Your profile picture URL</li>
+              </ul>
+              <p className="text-gray-700 dark:text-gray-300 mt-2">
+                We use this information solely to identify your account and personalize your experience (e.g., displaying your name and saving your favorite pools).
+              </p>
+
+              <h3 className="text-lg font-medium text-gray-800 dark:text-gray-200 mt-4 mb-2">
+                1.2 Information Collected Automatically
+              </h3>
+              <p className="text-gray-700 dark:text-gray-300">
+                We collect minimal technical information necessary to operate the Service:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Your approximate location (only when you grant permission, to show nearby pools)</li>
+                <li>Basic server logs (IP address, request timestamps) for security purposes</li>
+              </ul>
+
+              <h3 className="text-lg font-medium text-gray-800 dark:text-gray-200 mt-4 mb-2">
+                1.3 Information We Do NOT Collect
+              </h3>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>We do not use tracking cookies</li>
+                <li>We do not use third-party analytics that track you</li>
+                <li>We do not collect browsing history</li>
+                <li>We do not build advertising profiles</li>
+                <li>We do not sell any data to third parties</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                2. How We Use Your Information
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                We use the information we collect to:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Provide and maintain the Service</li>
+                <li>Save your preferences (favorite pools, display settings)</li>
+                <li>Show pools near your location (when you grant permission)</li>
+                <li>Respond to your inquiries and support requests</li>
+                <li>Protect against fraudulent or unauthorized use</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                3. Data Storage and Security
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                Your data is stored securely on our self-hosted infrastructure in Canada. We implement appropriate technical and organizational measures to protect your personal information, including:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Encrypted connections (HTTPS) for all data transmission</li>
+                <li>Secure authentication via Google OAuth</li>
+                <li>Regular security updates and monitoring</li>
+                <li>Limited access to personal data</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                4. Data Sharing
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                We do not sell, trade, or rent your personal information to third parties. We may share information only in the following circumstances:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>With your consent</li>
+                <li>To comply with legal obligations</li>
+                <li>To protect our rights or the safety of users</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                5. Your Rights
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                Under Canadian privacy law (PIPEDA) and other applicable regulations, you have the right to:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li><strong>Access</strong> your personal data</li>
+                <li><strong>Correct</strong> inaccurate information</li>
+                <li><strong>Delete</strong> your account and associated data</li>
+                <li><strong>Withdraw consent</strong> for data processing</li>
+                <li><strong>Export</strong> your data in a portable format</li>
+              </ul>
+              <p className="text-gray-700 dark:text-gray-300 mt-2">
+                To exercise these rights, contact us at{" "}
+                <a
+                  href="mailto:privacy@swimto.app"
+                  className="text-primary-600 dark:text-primary-400 hover:underline"
+                >
+                  privacy@swimto.app
+                </a>
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                6. Cookies and Local Storage
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                We use minimal cookies and local storage:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li><strong>Authentication tokens</strong> - To keep you signed in</li>
+                <li><strong>Preferences</strong> - Dark mode setting, favorite pools</li>
+              </ul>
+              <p className="text-gray-700 dark:text-gray-300 mt-2">
+                We do not use tracking cookies or third-party advertising cookies.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                7. Location Data
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                When you grant location permission, we use your approximate location to:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Show pools sorted by distance from you</li>
+                <li>Display your position on the map</li>
+              </ul>
+              <p className="text-gray-700 dark:text-gray-300 mt-2">
+                Your location is processed locally in your browser and is not stored on our servers. You can revoke location permission at any time through your browser settings.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                8. Children's Privacy
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                SwimTO is not directed at children under 13. We do not knowingly collect personal information from children under 13. If you believe a child has provided us with personal information, please contact us immediately.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                9. Changes to This Policy
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                We may update this Privacy Policy from time to time. We will notify you of any significant changes by posting a notice on the Service. Your continued use of the Service after changes constitutes acceptance of the updated policy.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                10. Contact Us
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                If you have questions about this Privacy Policy or our data practices, contact us at:
+              </p>
+              <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 mt-2">
+                <p className="text-gray-700 dark:text-gray-300">
+                  <strong>Email:</strong>{" "}
+                  <a
+                    href="mailto:privacy@swimto.app"
+                    className="text-primary-600 dark:text-primary-400 hover:underline"
+                  >
+                    privacy@swimto.app
+                  </a>
+                </p>
+                <p className="text-gray-700 dark:text-gray-300 mt-1">
+                  <strong>General Inquiries:</strong>{" "}
+                  <a
+                    href="mailto:hello@swimto.app"
+                    className="text-primary-600 dark:text-primary-400 hover:underline"
+                  >
+                    hello@swimto.app
+                  </a>
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -26,6 +26,9 @@ import {
   Star,
   Waves,
   Timer,
+  Share2,
+  Calendar as CalendarIcon,
+  Check,
 } from "lucide-react";
 import type { SwimType, Session } from "../types";
 
@@ -96,6 +99,90 @@ const formatTimeUntil = (session: Session): { text: string; isUrgent: boolean; i
     const hours = diffHours % 24;
     return { text: hours > 0 ? `${diffDays}d ${hours}h` : `${diffDays}d`, isUrgent, isToday };
   }
+};
+
+// Generate calendar event for a session
+const generateCalendarUrl = (session: Session): string => {
+  const start = new Date(`${session.date} ${session.start_time}`);
+  const end = new Date(`${session.date} ${session.end_time}`);
+  
+  // Format for Google Calendar
+  const formatGoogleDate = (date: Date) => {
+    return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+  };
+  
+  const title = encodeURIComponent(`${getSwimTypeLabel(session.swim_type)} at ${session.facility?.name || 'Pool'}`);
+  const details = encodeURIComponent(`Drop-in swim session\n\nTime: ${formatTimeRange(session.start_time, session.end_time)}\nType: ${getSwimTypeLabel(session.swim_type)}${session.notes ? `\nNotes: ${session.notes}` : ''}\n\nFound via SwimTO - swimto.app`);
+  const location = encodeURIComponent(session.facility?.address || '');
+  
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${formatGoogleDate(start)}/${formatGoogleDate(end)}&details=${details}&location=${location}`;
+};
+
+// Generate share text for a session
+const getShareText = (session: Session): { title: string; text: string; url: string } => {
+  const title = `${getSwimTypeLabel(session.swim_type)} at ${session.facility?.name || 'Pool'}`;
+  const text = `${getSwimTypeLabel(session.swim_type)} at ${session.facility?.name}\n${formatDate(session.date)} from ${formatTimeRange(session.start_time, session.end_time)}\n${session.facility?.address || ''}`;
+  const url = window.location.origin + '/schedule';
+  
+  return { title, text, url };
+};
+
+// Share Button Component
+const ShareButton = ({ session }: { session: Session }) => {
+  const [copied, setCopied] = useState(false);
+  
+  const handleShare = async () => {
+    const { title, text, url } = getShareText(session);
+    
+    // Use native share API if available (mobile)
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+      } catch {
+        // User cancelled or error - silently ignore
+      }
+    } else {
+      // Fallback: copy to clipboard
+      const fullText = `${text}\n\nFind more swim times at ${url}`;
+      await navigator.clipboard.writeText(fullText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+  
+  return (
+    <button
+      onClick={handleShare}
+      className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
+      aria-label="Share this session"
+      title="Share this session"
+    >
+      {copied ? (
+        <Check className="w-4 h-4 text-green-500" />
+      ) : (
+        <Share2 className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+      )}
+    </button>
+  );
+};
+
+// Calendar Button Component
+const CalendarButton = ({ session }: { session: Session }) => {
+  const handleAddToCalendar = () => {
+    const url = generateCalendarUrl(session);
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+  
+  return (
+    <button
+      onClick={handleAddToCalendar}
+      className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
+      aria-label="Add to calendar"
+      title="Add to Google Calendar"
+    >
+      <CalendarIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+    </button>
+  );
 };
 
 // Helper function to compare sessions for sorting
@@ -946,8 +1033,8 @@ export default function ScheduleView() {
                               </div>
                             </div>
 
-                            {/* Type */}
-                            <div className="flex-shrink-0">
+                            {/* Type + Actions */}
+                            <div className="flex-shrink-0 flex flex-col sm:flex-row items-end sm:items-center gap-2">
                               <span
                                 className={`px-4 py-2 rounded-xl text-xs font-bold ${getSwimTypeColor(
                                   session.swim_type
@@ -955,6 +1042,10 @@ export default function ScheduleView() {
                               >
                                 {getSwimTypeLabel(session.swim_type)}
                               </span>
+                              <div className="flex items-center gap-1">
+                                <ShareButton session={session} />
+                                <CalendarButton session={session} />
+                              </div>
                             </div>
                           </div>
 

--- a/apps/web/src/pages/TermsOfService.tsx
+++ b/apps/web/src/pages/TermsOfService.tsx
@@ -1,0 +1,168 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft, FileText } from "lucide-react";
+
+export default function TermsOfService() {
+  return (
+    <div className="min-h-[calc(100dvh-8rem)] bg-gray-50 dark:bg-gray-900 py-12 transition-colors duration-300">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-primary-600 dark:text-primary-400 hover:underline mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Home
+        </Link>
+
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 p-8 transition-colors duration-300">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
+              <FileText className="w-8 h-8 text-primary-600 dark:text-primary-400" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                Terms of Service
+              </h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Last updated: January 17, 2026
+              </p>
+            </div>
+          </div>
+
+          <div className="prose prose-blue dark:prose-invert max-w-none space-y-6">
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                1. Acceptance of Terms
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                By accessing and using SwimTO ("the Service"), you accept and agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Service.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                2. Description of Service
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                SwimTO is a web application that aggregates and displays indoor community pool drop-in swim schedules for the City of Toronto. The Service provides:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Interactive map of community pool locations</li>
+                <li>Schedule browser with filtering capabilities</li>
+                <li>Ability to save favorite facilities</li>
+                <li>Mobile-friendly interface</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                3. Data Sources
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                SwimTO uses data from the City of Toronto Open Data Portal, licensed under the{" "}
+                <a
+                  href="https://open.toronto.ca/open-data-license/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 dark:text-primary-400 hover:underline"
+                >
+                  Open Government Licence – Toronto
+                </a>
+                . While we strive to keep information accurate and up-to-date, we cannot guarantee the accuracy of schedule information. Always verify schedules with the facility directly before visiting.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                4. User Accounts
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                Some features require authentication via Google OAuth. By signing in, you agree to:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Provide accurate account information</li>
+                <li>Maintain the security of your account</li>
+                <li>Accept responsibility for all activities under your account</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                5. Acceptable Use
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                You agree not to:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 mt-2 space-y-1">
+                <li>Use the Service for any unlawful purpose</li>
+                <li>Attempt to gain unauthorized access to the Service</li>
+                <li>Interfere with or disrupt the Service</li>
+                <li>Use automated systems to access the Service excessively</li>
+                <li>Reproduce, duplicate, or resell the Service</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                6. Intellectual Property
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                The Service, including its original content, features, and functionality, is owned by SwimTO and is protected by copyright, trademark, and other intellectual property laws. The SwimTO name, logo, and all related marks are trademarks of SwimTO.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                7. Disclaimer of Warranties
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. We do not warrant that the Service will be uninterrupted, secure, or error-free. Schedule information may be inaccurate or outdated.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                8. Limitation of Liability
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                In no event shall SwimTO be liable for any indirect, incidental, special, consequential, or punitive damages resulting from your use of or inability to use the Service. This includes damages for loss of profits, data, or other intangibles, even if we have been advised of the possibility of such damages.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                9. Changes to Terms
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                We reserve the right to modify these terms at any time. We will notify users of significant changes by posting a notice on the Service. Your continued use of the Service after changes constitutes acceptance of the new terms.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                10. Governing Law
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                These Terms shall be governed by and construed in accordance with the laws of the Province of Ontario, Canada, without regard to its conflict of law provisions.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-8 mb-4">
+                11. Contact
+              </h2>
+              <p className="text-gray-700 dark:text-gray-300">
+                If you have any questions about these Terms, please contact us at{" "}
+                <a
+                  href="mailto:hello@swimto.app"
+                  className="text-primary-600 dark:text-primary-400 hover:underline"
+                >
+                  hello@swimto.app
+                </a>
+              </p>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -60,9 +60,8 @@ spec:
                 port:
                   number: 3000
 ---
-# Public domain Ingress (swimto.eldertree.xyz)
+# Public domain Ingress (swimto.eldertree.xyz - legacy)
 # Uses Cloudflare Origin Certificate - HTTPS termination handled by Cloudflare
-# Do NOT use redirect-https middleware (causes redirect loops with Cloudflare)
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -82,6 +81,49 @@ spec:
       secretName: swimto-cloudflare-origin-tls
   rules:
     - host: swimto.eldertree.xyz
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: swimto-api-service
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: swimto-web-service
+                port:
+                  number: 3000
+---
+# Primary public domain Ingress (swimto.app)
+# Uses Cloudflare Origin Certificate - HTTPS termination handled by Cloudflare
+# This is the main production domain for the app
+# NOTE: After purchasing swimto.app domain:
+# 1. Add domain to Cloudflare
+# 2. Create Cloudflare Origin Certificate for swimto.app
+# 3. Create k8s secret: kubectl create secret tls swimto-app-tls --cert=origin.pem --key=origin-key.pem -n swimto
+# 4. Configure DNS in Cloudflare to point to your server's public IP
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: swimto-app
+  namespace: swimto
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.middlewares: swimto-api-path-rewrite@kubernetescrd
+  labels:
+    app: swimto
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - swimto.app
+      secretName: swimto-app-tls
+  rules:
+    - host: swimto.app
       http:
         paths:
           - path: /api


### PR DESCRIPTION
## Summary
Professional polish and features for public launch of SwimTO.

## Changes

### Legal & Footer
- Add Terms of Service page (`/terms`)
- Add Privacy Policy page (`/privacy`)
- Enhanced footer with Quick Links, Legal, Data Source sections
- Added social links (email, GitHub)

### SEO & Social Sharing
- Add Open Graph meta tags for Facebook/Twitter link previews
- Add Twitter Card meta tags
- Add JSON-LD structured data for search engines
- Improved meta description and keywords
- Add canonical URL

### New Features
- **Share button** on session cards (native share API on mobile, clipboard on desktop)
- **Add to Calendar** button (Google Calendar integration)
- **PWA install prompt** with iOS-specific instructions
- New 'How It Works' section on landing page
- FAQ section with expandable questions
- 'Why SwimTO' feature highlights section

### Domain Configuration
- Add `swimto.app` ingress configuration (ready for domain purchase)
- Documentation for Cloudflare Origin Certificate setup

### Technical
- `usePWAInstall` hook for detecting install capability
- `InstallPrompt` component with iOS Safari instructions
- Slide-up animation for install banner

## Testing
- [x] TypeScript compiles without errors
- [ ] Visual testing on mobile and desktop
- [ ] PWA install tested on iOS and Android