### PR TITLE
fix(a11y): ensure all buttons meet 44px minimum tap targets (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **♿ Accessibility Improvements (#81)**: All interactive elements now meet 44px minimum tap target requirement
+  - ShareButton and CalendarButton in schedule view
+  - Favorite star buttons across list and table views
+  - Navigation buttons (prev/next day/week, today)
+  - Filter toggle and view mode buttons
+  - Distance buttons and modal cancel buttons
+  - Close buttons in map sidebar
+  - Location controls (Enable, Recenter, Disable)
+
+### Changed
+
+- **📚 Enhanced Z-Index Documentation (#50)**: Updated CSS variables and documentation
+  - Added PWA layer documentation (z-2500, z-3000)
+  - Added CSS variables for all z-index values
+  - Clear layer hierarchy from base content to PWA modals
+
 - **🔐 Multi-Domain OAuth Support**: Google OAuth now works across multiple domains
   - Dynamic redirect URI detection based on request origin
   - Supports `swimto.eldertree.xyz` (public), `swimto.eldertree.local` (internal), and `localhost` (dev)

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -26,12 +26,17 @@
    * - z-50: Maps modal, fullscreen overlays
    * 
    * LAYER 4: Fixed Navigation (2000-2001)
-   * - z-2000: Main header/nav (always above everything except toasts)
-   * - z-2001: Login error popup (above header)
+   * - z-[2000]: Main header/nav (always above everything except toasts/PWA prompts)
+   * - z-[2001]: Login error popup (above header)
+   * 
+   * LAYER 5: PWA Install Prompts (2500-3000)
+   * - z-[2500]: PWA install prompt banner (above header)
+   * - z-[3000]: PWA install modal with backdrop (topmost layer)
    * 
    * Usage notes:
-   * - Tailwind classes: z-10, z-20, z-30, z-50, z-[2000], z-[2001]
-   * - Modals should use z-50
+   * - Tailwind classes: z-10, z-20, z-30, z-50, z-[2000], z-[2001], z-[2500], z-[3000]
+   * - Regular modals should use z-50
+   * - PWA prompts use z-[2500] and z-[3000] to appear above navigation
    * - Never use z-index values between 50 and 2000 to leave room for future layers
    */
   --z-map-search: 10;
@@ -42,6 +47,8 @@
   --z-modal: 50;
   --z-header: 2000;
   --z-header-popup: 2001;
+  --z-pwa-banner: 2500;
+  --z-pwa-modal: 3000;
 }
 
 body {

--- a/apps/web/src/pages/MapView.tsx
+++ b/apps/web/src/pages/MapView.tsx
@@ -406,7 +406,7 @@ export default function MapView() {
                   setSearchQuery("");
                   setHighlightedFacilityId(null);
                 }}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                className="absolute right-3 top-1/2 -translate-y-1/2 min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -532,7 +532,7 @@ export default function MapView() {
                           onClick={() =>
                             handleToggleFavorite(facility.facility_id)
                           }
-                          className="flex-shrink-0 hover:scale-110 transition-transform duration-200"
+                          className="flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center hover:scale-110 transition-transform duration-200"
                           aria-label={
                             isFavorited
                               ? "Remove from favorites"
@@ -545,7 +545,7 @@ export default function MapView() {
                           }
                         >
                           <Star
-                            className={`w-5 h-5 ${
+                            className={`w-6 h-6 ${
                               isFavorited
                                 ? "fill-yellow-400 text-yellow-400"
                                 : "text-gray-300 hover:text-yellow-400"
@@ -562,7 +562,7 @@ export default function MapView() {
                       {facility.distance !== undefined && facility.address && (
                         <button
                           onClick={() => setMapsModalAddress(facility.address!)}
-                          className="bg-green-50 p-2 rounded mb-2 w-full hover:bg-green-100 transition-colors cursor-pointer text-left"
+                          className="bg-green-50 min-h-[44px] p-2 rounded mb-2 w-full hover:bg-green-100 transition-colors cursor-pointer text-left"
                           title="Open in maps"
                         >
                           <p className="text-xs font-semibold text-green-900 flex items-center gap-1">
@@ -628,7 +628,7 @@ export default function MapView() {
         <div className="absolute top-20 md:top-4 left-4 right-4 md:left-auto md:right-4 md:w-80 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 max-h-[calc(100dvh-16rem)] md:max-h-[calc(100dvh-12rem)] overflow-y-auto z-20">
           <button
             onClick={() => setSelectedFacility(null)}
-            className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+            className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
             aria-label="Close facility details"
           >
             ✕
@@ -651,7 +651,7 @@ export default function MapView() {
             </h2>
             <button
               onClick={() => handleToggleFavorite(selectedFacility.facility_id)}
-              className="flex-shrink-0 hover:scale-110 transition-transform duration-200"
+              className="flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center hover:scale-110 transition-transform duration-200"
               aria-label={
                 isFavorite(selectedFacility.facility_id)
                   ? "Remove from favorites"
@@ -706,7 +706,7 @@ export default function MapView() {
             selectedFacility.address && (
               <button
                 onClick={() => setMapsModalAddress(selectedFacility.address!)}
-                className="bg-green-50 dark:bg-green-900/20 p-3 rounded-lg mb-3 w-full hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors cursor-pointer text-left"
+                className="bg-green-50 dark:bg-green-900/20 min-h-[44px] p-3 rounded-lg mb-3 w-full hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors cursor-pointer text-left"
                 title="Open in maps"
               >
                 <p className="text-xs font-semibold text-green-900 dark:text-green-400 mb-1 flex items-center gap-1">
@@ -770,7 +770,7 @@ export default function MapView() {
                   </div>
                   <button
                     onClick={handleGetLocation}
-                    className="text-xs px-3 py-1 rounded bg-gray-100 dark:bg-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1"
+                    className="min-h-[44px] text-xs px-3 py-1 rounded bg-gray-100 dark:bg-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1"
                     title="Recenter map on your location"
                   >
                     <Navigation className="w-3 h-3" />
@@ -785,7 +785,7 @@ export default function MapView() {
                       setSortByDistance(false);
                       setLocationError(null);
                     }}
-                    className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
+                    className="min-h-[44px] px-2 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
                   >
                     Disable
                   </button>
@@ -803,7 +803,7 @@ export default function MapView() {
                 ) : null}
                 <button
                   onClick={handleGetLocation}
-                  className="flex items-center justify-center gap-2 bg-primary-500 dark:bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-600 dark:hover:bg-primary-700 transition-colors text-sm"
+                  className="min-h-[44px] flex items-center justify-center gap-2 bg-primary-500 dark:bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-600 dark:hover:bg-primary-700 transition-colors text-sm"
                 >
                   <Navigation className="w-4 h-4" />
                   Enable Location
@@ -917,7 +917,7 @@ export default function MapView() {
 
             <button
               onClick={() => setMapsModalAddress(null)}
-              className="mt-4 w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+              className="mt-4 w-full min-h-[44px] px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
             >
               Cancel
             </button>

--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -153,7 +153,7 @@ const ShareButton = ({ session }: { session: Session }) => {
   return (
     <button
       onClick={handleShare}
-      className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
+      className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
       aria-label="Share this session"
       title="Share this session"
     >
@@ -176,7 +176,7 @@ const CalendarButton = ({ session }: { session: Session }) => {
   return (
     <button
       onClick={handleAddToCalendar}
-      className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
+      className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
       aria-label="Add to calendar"
       title="Add to Google Calendar"
     >
@@ -758,7 +758,7 @@ export default function ScheduleView() {
             <div className="flex items-center justify-center gap-4 mt-6">
               <button
                 onClick={() => setWeekOffset(weekOffset - 1)}
-                className="px-3 py-2 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 hover:bg-primary-50 dark:hover:bg-gray-700 hover:border-primary-300 dark:hover:border-primary-500 transition-all font-medium text-gray-700 dark:text-gray-300 hover:text-primary-700 dark:hover:text-primary-400 shadow-sm text-sm"
+                className="min-h-[44px] px-3 py-2 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 hover:bg-primary-50 dark:hover:bg-gray-700 hover:border-primary-300 dark:hover:border-primary-500 transition-all font-medium text-gray-700 dark:text-gray-300 hover:text-primary-700 dark:hover:text-primary-400 shadow-sm text-sm"
               >
                 ← Prev
               </button>
@@ -789,7 +789,7 @@ export default function ScheduleView() {
 
               <button
                 onClick={() => setWeekOffset(weekOffset + 1)}
-                className="px-3 py-2 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 hover:bg-primary-50 dark:hover:bg-gray-700 hover:border-primary-300 dark:hover:border-primary-500 transition-all font-medium text-gray-700 dark:text-gray-300 hover:text-primary-700 dark:hover:text-primary-400 shadow-sm text-sm"
+                className="min-h-[44px] px-3 py-2 rounded-lg bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 hover:bg-primary-50 dark:hover:bg-gray-700 hover:border-primary-300 dark:hover:border-primary-500 transition-all font-medium text-gray-700 dark:text-gray-300 hover:text-primary-700 dark:hover:text-primary-400 shadow-sm text-sm"
               >
                 Next →
               </button>
@@ -797,7 +797,7 @@ export default function ScheduleView() {
               {weekOffset !== 0 && (
                 <button
                   onClick={() => setWeekOffset(0)}
-                  className="px-3 py-2 rounded-lg bg-primary-500 dark:bg-primary-600 text-white hover:bg-primary-600 dark:hover:bg-primary-700 transition-all font-medium shadow-sm text-sm"
+                  className="min-h-[44px] px-3 py-2 rounded-lg bg-primary-500 dark:bg-primary-600 text-white hover:bg-primary-600 dark:hover:bg-primary-700 transition-all font-medium shadow-sm text-sm"
                   title="Go to today"
                 >
                   Today
@@ -812,7 +812,7 @@ export default function ScheduleView() {
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
             <button
               onClick={() => setShowFilters(!showFilters)}
-              className="flex items-center gap-2 text-gray-700 dark:text-gray-300 font-semibold md:hidden hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+              className="min-h-[44px] flex items-center gap-2 text-gray-700 dark:text-gray-300 font-semibold md:hidden hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
             >
               <Filter className="w-5 h-5" />
               Filters
@@ -912,7 +912,7 @@ export default function ScheduleView() {
               <div className="hidden md:flex gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5 ml-auto">
                 <button
                   onClick={() => setViewMode("list")}
-                  className={`flex items-center gap-1.5 px-4 py-2 rounded-md font-medium transition-all duration-300 text-sm ${
+                  className={`min-h-[44px] flex items-center gap-1.5 px-4 py-2 rounded-md font-medium transition-all duration-300 text-sm ${
                     viewMode === "list"
                       ? "bg-white dark:bg-gray-800 text-primary-600 dark:text-primary-400 shadow-md"
                       : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
@@ -923,7 +923,7 @@ export default function ScheduleView() {
                 </button>
                 <button
                   onClick={() => setViewMode("table")}
-                  className={`flex items-center gap-1.5 px-4 py-2 rounded-md font-medium transition-all duration-300 text-sm ${
+                  className={`min-h-[44px] flex items-center gap-1.5 px-4 py-2 rounded-md font-medium transition-all duration-300 text-sm ${
                     viewMode === "table"
                       ? "bg-white dark:bg-gray-800 text-primary-600 dark:text-primary-400 shadow-md"
                       : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
@@ -1037,7 +1037,7 @@ export default function ScheduleView() {
                                     session.facility?.facility_id
                                   )
                                 }
-                                className="flex-shrink-0 hover:scale-110 transition-transform duration-200 mt-1"
+                                className="flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center hover:scale-110 transition-transform duration-200"
                                 aria-label={
                                   favorites.has(
                                     session.facility?.facility_id || ""
@@ -1054,7 +1054,7 @@ export default function ScheduleView() {
                                 }
                               >
                                 <Star
-                                  className={`w-5 h-5 ${
+                                  className={`w-6 h-6 ${
                                     favorites.has(
                                       session.facility?.facility_id || ""
                                     )
@@ -1268,7 +1268,7 @@ export default function ScheduleView() {
                             onClick={() =>
                               handleToggleFavorite(data.facility?.facility_id)
                             }
-                            className="flex-shrink-0 mt-1 hover:scale-110 transition-transform duration-200 p-1.5 rounded-lg hover:bg-yellow-50 dark:hover:bg-yellow-900/20"
+                            className="flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center hover:scale-110 transition-transform duration-200 rounded-lg hover:bg-yellow-50 dark:hover:bg-yellow-900/20"
                             aria-label={
                               isFavorite(data.facility?.facility_id || "")
                                 ? "Remove from favorites"
@@ -1281,7 +1281,7 @@ export default function ScheduleView() {
                             }
                           >
                             <Star
-                              className={`w-5 h-5 sm:w-6 sm:h-6 transition-all duration-200 ${
+                              className={`w-6 h-6 transition-all duration-200 ${
                                 isFavorite(data.facility?.facility_id || "")
                                   ? "fill-yellow-400 text-yellow-400 scale-110"
                                   : "text-gray-300 dark:text-gray-600 hover:text-yellow-400 dark:hover:text-yellow-400"
@@ -1309,7 +1309,7 @@ export default function ScheduleView() {
                                   onClick={() =>
                                     setMapsModalAddress(data.facility!.address!)
                                   }
-                                  className="mb-2 px-2 py-1 text-sm font-semibold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 rounded-md hover:bg-green-100 dark:hover:bg-green-900/30 hover:text-green-700 dark:hover:text-green-300 cursor-pointer transition-all duration-200 flex items-center gap-1.5"
+                                  className="mb-2 min-h-[44px] px-3 py-2 text-sm font-semibold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 rounded-md hover:bg-green-100 dark:hover:bg-green-900/30 hover:text-green-700 dark:hover:text-green-300 cursor-pointer transition-all duration-200 flex items-center gap-1.5"
                                   title="Open in maps"
                                 >
                                   <Navigation className="w-4 h-4" />
@@ -1475,7 +1475,7 @@ export default function ScheduleView() {
                                       }
                                       setExpandedCells(newExpanded);
                                     }}
-                                    className="w-full mt-2 px-2 py-1.5 text-xs font-semibold text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 rounded-md hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 transition-all duration-200"
+                                    className="w-full mt-2 min-h-[44px] px-2 py-2 text-xs font-semibold text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 rounded-md hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 transition-all duration-200"
                                   >
                                     {isExpanded
                                       ? "Show less"
@@ -1571,7 +1571,7 @@ export default function ScheduleView() {
 
             <button
               onClick={() => setMapsModalAddress(null)}
-              className="mt-4 w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+              className="mt-4 w-full min-h-[44px] px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg font-semibold hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
             >
               Cancel
             </button>


### PR DESCRIPTION
- ShareButton and CalendarButton: Added min-h-[44px] min-w-[44px]
- Favorite star buttons: Added min-h-[44px] min-w-[44px] in list and table views
- Navigation buttons: Added min-h-[44px] to desktop week nav buttons
- Filter toggle button: Added min-h-[44px]
- View mode toggle buttons: Added min-h-[44px]
- Distance buttons: Added min-h-[44px] to table view distance button
- Show more button: Added min-h-[44px] to expand/collapse button
- Modal cancel buttons: Added min-h-[44px] in both ScheduleView and MapView
- MapView buttons: Added min-h-[44px] to close, favorite, distance, location buttons

Also:
- docs(css): enhanced z-index documentation with PWA layers (#50)
- Updated CHANGELOG with accessibility improvements