### PR TITLE
feat(ui): add Pitanga Cloud branding to footer

### DIFF
--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -13,13 +13,13 @@ import {
   X,
   Mail,
   Github,
-  Heart,
   Home,
 } from "lucide-react";
 import { useDarkMode } from "../contexts/DarkModeContext";
 import { useAuth } from "../contexts/useAuth";
 import { useState, useEffect } from "react";
 import { InstallPrompt } from "./InstallPrompt";
+import { PitangaMark } from "./PitangaMark";
 
 export default function Layout() {
   const { isDarkMode, toggleDarkMode } = useDarkMode();
@@ -338,10 +338,16 @@ export default function Layout() {
                 © {new Date().getFullYear()} SwimTO. All rights reserved.
               </p>
               <div className="flex items-center gap-4">
-                <p className="text-sm text-gray-500 flex items-center gap-1">
-                  Made with <Heart className="w-4 h-4 text-red-500 fill-red-500" />{" "}
-                  in Toronto
-                </p>
+                <a 
+                  href="https://pitanga.cloud" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-sm text-gray-500 hover:text-gray-300 flex items-center gap-2 transition-colors"
+                  title="Visit Pitanga Cloud"
+                >
+                  <PitangaMark className="w-5 h-5" />
+                  <span>A Pitanga Cloud project</span>
+                </a>
                 <span className="text-xs text-gray-600 font-mono">
                   v{import.meta.env.VITE_APP_VERSION || "dev"}
                 </span>

--- a/apps/web/src/components/PitangaMark.tsx
+++ b/apps/web/src/components/PitangaMark.tsx
@@ -1,0 +1,55 @@
+/**
+ * Pitanga Mark Logo
+ * - Refined leaf geometry with subtle stem
+ * - Berries with characteristic 8-ribbed profile suggestion
+ * - Balanced, architectural composition for a formal corporate feel
+ */
+export const PitangaMark = ({ className = "w-8 h-8" }: { className?: string }) => (
+  <svg 
+    viewBox="0 0 32 32" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    {/* Central Stem - Very subtle anchor */}
+    <path d="M16 11V14" stroke="#768153" strokeWidth="0.75" strokeLinecap="round" />
+    
+    {/* Refined Leaves - More fluid, organic yet structured */}
+    <path 
+      d="M16 11.5C16 11.5 15.2 7 12.5 7C9.8 7 9.5 9.5 9.5 10C9.5 10.5 9.8 13.5 13 13.5C15.2 13.5 16 11.5 16 11.5Z" 
+      fill="#768153" 
+    />
+    <path 
+      d="M16 11.5C16 11.5 16.8 7 19.5 7C22.2 7 22.5 9.5 22.5 10C22.5 10.5 22.2 13.5 19 13.5C16.8 13.5 16 11.5 16 11.5Z" 
+      fill="#768153" 
+      fillOpacity="0.85" 
+    />
+    
+    {/* Berries - Geometric abstraction of the 8-ribbed Pitanga fruit */}
+    {/* Left Berry */}
+    <g>
+      <circle cx="11.5" cy="18.5" r="3.8" fill="#8B261E" />
+      <path d="M11.5 15.5V17.5" stroke="white" strokeOpacity="0.15" strokeWidth="0.5" />
+      <path d="M9.5 18.5H10.5" stroke="white" strokeOpacity="0.15" strokeWidth="0.5" />
+    </g>
+    
+    {/* Right Berry */}
+    <g>
+      <circle cx="20.5" cy="18.5" r="3.8" fill="#8B261E" />
+      <path d="M20.5 15.5V17.5" stroke="white" strokeOpacity="0.15" strokeWidth="0.5" />
+      <path d="M21.5 18.5H22.5" stroke="white" strokeOpacity="0.15" strokeWidth="0.5" />
+    </g>
+    
+    {/* Center Berry (Foreground) */}
+    <g>
+      <circle cx="16" cy="23.8" r="4.2" fill="#8B261E" />
+      <circle cx="16" cy="23.8" r="4.2" stroke="#FCFCFB" strokeWidth="0.5" />
+      {/* Subtle ribbed detail */}
+      <path d="M16 20.5V22" stroke="white" strokeOpacity="0.2" strokeWidth="0.5" />
+      <path d="M14 23.8H15" stroke="white" strokeOpacity="0.2" strokeWidth="0.5" />
+      <path d="M17 23.8H18" stroke="white" strokeOpacity="0.2" strokeWidth="0.5" />
+    </g>
+  </svg>
+);
+
+export default PitangaMark;


### PR DESCRIPTION
Adds Pitanga Cloud branding to the swimTO footer.

## Changes
- Added PitangaMark SVG component (the berry logo)
- Replaced 'Made with ❤️ in Toronto' with 'A Pitanga Cloud project'
- Links to https://pitanga.cloud/

## Preview
Footer now shows: © 2026 SwimTO. All rights reserved. | [Pitanga Logo] A Pitanga Cloud project | v0.7.0