### PR TITLE
fix(auth): add swimto.app to allowed origins for OAuth

### DIFF
--- a/apps/api/app/routes/auth.py
+++ b/apps/api/app/routes/auth.py
@@ -15,6 +15,7 @@ router = APIRouter()
 
 # Allowed redirect URI origins (for security - prevent open redirect attacks)
 ALLOWED_ORIGINS = [
+    "https://swimto.app",
     "https://swimto.eldertree.xyz",
     "https://swimto.eldertree.local",
     "http://swimto.eldertree.local",


### PR DESCRIPTION
Adds https://swimto.app to the ALLOWED_ORIGINS list in the auth routes, enabling OAuth login from the swimto.app domain.