### PR TITLE
chore: remove unused OpenAI/Leonardo API key config

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -44,10 +44,6 @@ class Settings(BaseSettings):
     # External APIs
     city_base_url: str = "https://www.toronto.ca"
     open_data_base_url: str = "https://open.toronto.ca"
-    
-    # AI Image Generation APIs
-    openai_api_key: Optional[str] = None  # Overridden by OPENAI_API_KEY env var from Vault in production
-    leonardo_api_key: Optional[str] = None  # Overridden by LEONARDO_API_KEY env var from Vault in production
 
     # Ingestion
     ingest_window_days: int = 56

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
       OPEN_DATA_BASE_URL: https://open.toronto.ca
       INGEST_WINDOW_DAYS: 56
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      LEONARDO_API_KEY: ${LEONARDO_API_KEY:-}
     ports:
       - "${SWIMTO_API_PORT:-8000}:8000"
     depends_on:

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -64,18 +64,6 @@ spec:
                 secretKeyRef:
                   name: swimto-secrets
                   key: SECRET_KEY
-            - name: OPENAI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: swimto-secrets
-                  key: OPENAI_API_KEY
-                  optional: true
-            - name: LEONARDO_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: swimto-secrets
-                  key: LEONARDO_API_KEY
-                  optional: true
             - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Remove unused `openai_api_key` and `leonardo_api_key` config fields
- These were vestigial from a planned feature that was never implemented
- SwimTO is a pool finder app and doesn't need image generation APIs

## Changes

- `apps/api/app/config.py` - Remove AI Image Generation APIs section
- `docker-compose.yml` - Remove env vars
- `k8s/api-deployment.yaml` - Remove env vars

## Test plan

- [x] App still starts without these config fields
- [x] No code references these settings