### PR TITLE
feat: Add free vs paid pool tagging (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Free vs Paid Pool Tagging**: Users can now identify free pools at a glance with a "FREE" badge displayed on pool listings. A "Show free pools only" filter checkbox allows filtering to display only pools with free entry. This feature addresses user feedback from Reddit requesting the ability to distinguish between free and paid pools. (#105)
+  - Added `is_free_entry` boolean field to `Facility` model (API and data-pipeline)
+  - Added database migration `002_add_is_free_entry.sql` with index for efficient filtering
+  - Added `?is_free=true` query parameter to `/api/v1/facilities` endpoint
+  - Added visual "FREE" badge component displayed next to facility names in both list and table views
+  - Added "Show free pools only" checkbox filter in the schedule view
+  - Note: Phase 1 defaults all pools to paid (`is_free_entry=false`). Future work will research and map actual free Toronto pools.
+
+---
+
 ## [0.8.1] - 2026-04-02
 
 ### Fixed

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -56,6 +56,7 @@ class Facility(Base):
     phone = Column(String(20))
     website = Column(Text)
     source = Column(String(50))
+    is_free_entry = Column(Boolean, default=False, nullable=False)
     raw = Column(JSONType)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/apps/api/app/routes/facilities.py
+++ b/apps/api/app/routes/facilities.py
@@ -24,16 +24,20 @@ async def get_facilities(
     request: Request,  # Required for rate limiting
     district: Optional[str] = Query(None, description="Filter by district"),
     has_lane_swim: bool = Query(False, description="Only facilities with lane swim"),
+    is_free: Optional[bool] = Query(None, description="Filter by free entry"),
     db: Session = Depends(get_db)
 ):
     """Get all facilities with enriched session data."""
     try:
-        logger.info(f"Fetching facilities (district={district}, has_lane_swim={has_lane_swim})")
-        
+        logger.info(f"Fetching facilities (district={district}, has_lane_swim={has_lane_swim}, is_free={is_free})")
+
         query = db.query(Facility).filter(Facility.is_indoor.is_(True))
-        
+
         if district:
             query = query.filter(Facility.district.ilike(f"%{district}%"))
+
+        if is_free is not None:
+            query = query.filter(Facility.is_free_entry == is_free)
         
         facilities = query.all()
         logger.debug(f"Found {len(facilities)} facilities")

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -16,6 +16,7 @@ class FacilityBase(BaseModel):
     is_indoor: bool = True
     phone: Optional[str] = None
     website: Optional[str] = None
+    is_free_entry: bool = False
 
 
 class FacilityCreate(FacilityBase):

--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -173,7 +173,7 @@ const CalendarButton = ({ session }: { session: Session }) => {
     const url = generateCalendarUrl(session);
     window.open(url, '_blank', 'noopener,noreferrer');
   };
-  
+
   return (
     <button
       onClick={handleAddToCalendar}
@@ -183,6 +183,15 @@ const CalendarButton = ({ session }: { session: Session }) => {
     >
       <CalendarIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
     </button>
+  );
+};
+
+// Free Entry Badge Component
+const FreeEntryBadge = () => {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border border-green-200 dark:border-green-700">
+      FREE
+    </span>
   );
 };
 
@@ -257,6 +266,7 @@ export default function ScheduleView() {
   const { favorites, isFavorite, toggleFavorite } = useFavorites();
   const [swimType, setSwimType] = useState<SwimType | "ALL">("LANE_SWIM");
   const [ageFilter, setAgeFilter] = useState<AgeFilter>("all");
+  const [showFreeOnly, setShowFreeOnly] = useState(false);
   // Time-of-day filter: default is full day [5am, 11pm]
   const TIME_MIN = 5 * 60;
   const TIME_MAX = 23 * 60;
@@ -352,12 +362,15 @@ export default function ScheduleView() {
     return new Set(allSessions.map((s) => s.swim_type));
   }, [allSessions]);
 
-  // Filter sessions by swimType and selected time-of-day range (client-side)
+  // Filter sessions by swimType, free entry, and selected time-of-day range (client-side)
   const sessions = useMemo(() => {
     if (!allSessions) return undefined;
     let filtered = allSessions;
     if (swimType !== "ALL") {
       filtered = filtered.filter((s) => s.swim_type === swimType);
+    }
+    if (showFreeOnly) {
+      filtered = filtered.filter((s) => s.facility?.is_free_entry === true);
     }
     if (!isTimeDefault) {
       filtered = filtered.filter((s) => {
@@ -370,7 +383,7 @@ export default function ScheduleView() {
       });
     }
     return filtered;
-  }, [allSessions, swimType, isTimeDefault, timeStart, timeEnd]);
+  }, [allSessions, swimType, showFreeOnly, isTimeDefault, timeStart, timeEnd]);
 
   // Handle toggling favorites
   const handleToggleFavorite = async (facilityId: string | undefined) => {
@@ -1057,6 +1070,21 @@ export default function ScheduleView() {
             />
           </div>
 
+          {/* Free Entry Filter */}
+          <div className="mt-3 mb-1">
+            <label className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors min-h-[44px]">
+              <input
+                type="checkbox"
+                checked={showFreeOnly}
+                onChange={(e) => setShowFreeOnly(e.target.checked)}
+                className="w-5 h-5 rounded border-gray-300 dark:border-gray-600 text-green-500 focus:ring-green-500 focus:ring-offset-0 cursor-pointer"
+              />
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Show free pools only
+              </span>
+            </label>
+          </div>
+
           <div className={`${showFilters ? "block" : "hidden"} md:block mt-2`}>
             {/* Swim Type Filter Chips - Horizontal scrollable on mobile, wrapping on desktop */}
             <div className="overflow-x-auto pb-2 -mx-3 px-3 sm:mx-0 sm:px-0 sm:overflow-visible scrollbar-hide">
@@ -1214,6 +1242,9 @@ export default function ScheduleView() {
                                   ) : (
                                     data.facility?.name
                                   )}
+                                  {data.facility?.is_free_entry && (
+                                    <FreeEntryBadge />
+                                  )}
                                 </h3>
                                 <div className="flex items-center gap-2 mt-1 flex-wrap">
                                   {data.distance !== undefined && (
@@ -1370,6 +1401,9 @@ export default function ScheduleView() {
                                       </a>
                                     ) : (
                                       session.facility?.name
+                                    )}
+                                    {session.facility?.is_free_entry && (
+                                      <span className="ml-2 inline-block"><FreeEntryBadge /></span>
                                     )}
                                     {session.distance !== undefined &&
                                       session.facility?.address && (
@@ -1592,6 +1626,9 @@ export default function ScheduleView() {
                                 </a>
                               ) : (
                                 data.facility?.name || "Unknown"
+                              )}
+                              {data.facility?.is_free_entry && (
+                                <span className="ml-2 inline-block"><FreeEntryBadge /></span>
                               )}
                             </div>
                             {data.distance !== undefined &&

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Facility {
   is_indoor: boolean
   phone: string | null
   website: string | null
+  is_free_entry: boolean
   source: string | null
   created_at: string
   updated_at: string

--- a/data-pipeline/models.py
+++ b/data-pipeline/models.py
@@ -27,6 +27,7 @@ class Facility(Base):
     phone = Column(String(20))
     website = Column(Text)
     source = Column(String(50))
+    is_free_entry = Column(Boolean, default=False, nullable=False)
     raw = Column(JSONB)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/scripts/migrations/002_add_is_free_entry.sql
+++ b/scripts/migrations/002_add_is_free_entry.sql
@@ -1,0 +1,13 @@
+-- Migration: Add is_free_entry column to facilities table
+-- Date: 2026-05-26
+-- Description: Add boolean field to indicate whether a pool has free entry
+
+-- Add is_free_entry column (defaults to FALSE for paid entry)
+ALTER TABLE facilities
+ADD COLUMN is_free_entry BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add comment for documentation
+COMMENT ON COLUMN facilities.is_free_entry IS 'Indicates whether the facility has free entry (TRUE) or requires payment (FALSE)';
+
+-- Create index for filtering by free entry
+CREATE INDEX idx_facilities_is_free_entry ON facilities(is_free_entry);


### PR DESCRIPTION
## Summary
Adds free vs paid pool tagging to help users identify free swimming opportunities at a glance. This addresses user feedback from Reddit (#105) requesting the ability to distinguish between free and paid pools.

## Changes
### Backend
- ✅ Add `is_free_entry` boolean field to `Facility` model (API and data-pipeline)
- ✅ Create database migration `002_add_is_free_entry.sql` with index for filtering
- ✅ Add `?is_free=true` query parameter to `/api/v1/facilities` endpoint
- ✅ Update Pydantic schemas to include `is_free_entry` field

### Frontend
- ✅ Update TypeScript `Facility` interface with `is_free_entry` field
- ✅ Create `FreeEntryBadge` component with green styling
- ✅ Display "FREE" badge next to facility names in list and table views
- ✅ Add "Show free pools only" checkbox filter
- ✅ Filter sessions client-side by `is_free_entry` field

### Documentation
- ✅ Update CHANGELOG.md with feature details

## Test Plan
### Backend
- [ ] Run API tests: `cd apps/api && pytest tests/`
- [ ] Verify migration applies cleanly to production database
- [ ] Test `/api/v1/facilities?is_free=true` endpoint returns filtered results

### Frontend
- [ ] Verify "FREE" badge displays correctly when `is_free_entry === true`
- [ ] Test "Show free pools only" checkbox filter
- [ ] Mobile responsiveness check (list view)
- [ ] Desktop table view badge placement

### End-to-End
1. Start development environment: `make dev`
2. Mock a facility with `is_free_entry=true` in database
3. Verify badge appears on UI
4. Toggle filter and verify results update

## Phase 1 Note
⚠️ This PR defaults all pools to **paid** (`is_free_entry=false`). Phase 2 will research Toronto.ca to identify actual free pools and populate the data accordingly.

## Follow-up Issues
- [ ] Create issue: "Research and map free Toronto pools" with links to toronto.ca pricing pages
- [ ] Consider adding `pricing_notes` text field for variable pricing (e.g., "free for seniors")

## Closes
#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)