### PR TITLE
docs: add version and CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # 🏊‍♂️ SwimTO
 
+![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
+![Node](https://img.shields.io/badge/node-20+-green.svg)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688.svg)
+![React](https://img.shields.io/badge/React-18.2-61DAFB.svg?logo=react)
+![PR Checks](https://github.com/raolivei/swimTO/actions/workflows/pr.yml/badge.svg)
+![Build](https://github.com/raolivei/swimTO/actions/workflows/build-and-push.yml/badge.svg)
+
 **SwimTO** aggregates and displays indoor community pool drop-in swim schedules for the City of Toronto.
 
 > **⚠️ COMMERCIAL PROJECT:** This is proprietary software. All rights reserved. See [LICENSE](LICENSE) and [PROJECT_STRATEGY.md](PROJECT_STRATEGY.md) for details.


### PR DESCRIPTION
## Summary
- Added version badges for Python 3.11+, Node 20+, FastAPI 0.115, React 18.2
- Added CI status badges for PR checks and build workflows
- Improves project discoverability and communicates requirements at a glance

## Test plan
- [x] Badges render correctly in README
- [x] Badge URLs link to correct resources (shields.io for versions, GitHub Actions for CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)