### PR TITLE
fix: deploy scripts use postgres/pools credentials

### DIFF
--- a/scripts/deploy-outdoor-pools.sh
+++ b/scripts/deploy-outdoor-pools.sh
@@ -15,18 +15,24 @@ fi
 echo "1. Run DB migration 003..."
 "${ROOT}/scripts/run-migration.sh" "${MIGRATION}"
 
-echo "2. Reconcile Flux (swimto HelmRelease)..."
-flux reconcile helmrelease swimto -n swimto --with-source || true
+echo "2. Ensure migration 002 (is_free_entry) is applied..."
+if ! kubectl exec -n swimto deploy/postgres -- psql -U postgres -d pools -tAc \
+  "SELECT 1 FROM information_schema.columns WHERE table_name='facilities' AND column_name='is_free_entry'" | grep -q 1; then
+  "${ROOT}/scripts/run-migration.sh" "${ROOT}/scripts/migrations/002_add_is_free_entry.sql"
+fi
 
-echo "3. Wait for API rollout..."
+echo "3. Reconcile Flux (swimto HelmRelease) — optional, may take several minutes..."
+flux reconcile helmrelease swimto -n swimto --with-source --timeout=10m || true
+
+echo "4. Wait for API rollout..."
 kubectl rollout status deployment/swimto-api -n swimto --timeout=300s || \
   kubectl rollout status deployment/swimto-swimto-api -n swimto --timeout=300s || true
 
-echo "4. Trigger data refresh (Ourland + pool type flags)..."
+echo "5. Trigger data refresh (Ourland + pool type flags)..."
 kubectl create job --from=cronjob/swimto-data-refresh "swimto-refresh-outdoor-$(date +%s)" -n swimto || \
   kubectl create job --from=cronjob/swimto-data-refresh "swimto-refresh-manual-$(date +%s)" -n swimto
 
-echo "5. Verify API pool_type filter..."
+echo "6. Verify API pool_type filter..."
 curl -fsS "https://swimto.app/api/facilities?pool_type=outdoor&has_lane_swim=true" | head -c 200
 echo ""
 echo "=== Done. Open https://swimto.app/map and test All / Indoor / Outdoor filter ==="

--- a/scripts/run-migration.sh
+++ b/scripts/run-migration.sh
@@ -60,7 +60,7 @@ else
     kubectl cp "$MIGRATION_FILE" "swimto/$POD:/tmp/migration.sql"
     
     # Run migration
-    kubectl exec -n swimto "$POD" -- psql -U swimto -d swimto -f /tmp/migration.sql
+    kubectl exec -n swimto "$POD" -- psql -U postgres -d pools -f /tmp/migration.sql
     
     # Clean up
     kubectl exec -n swimto "$POD" -- rm /tmp/migration.sql


### PR DESCRIPTION
Fixes run-migration.sh kubectl path (postgres/pools not swimto/swimto). Deploy script also ensures migration 002 before 003.

Made with [Cursor](https://cursor.com)