### PR TITLE
fix(ci): build swimto-web on ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,5 +39,7 @@ jobs:
     with:
       image-name: swimto-web
       context: ./apps/web
+      # ARC Pi runners hit npm flake/timeouts; web is static nginx — build on GitHub-hosted.
+      runs-on: ubuntu-latest
     secrets:
       REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI web image build**: `build-web` uses `ubuntu-latest` instead of ARC self-hosted runners (npm flake on Pi).
+
 ## [0.8.3] - 2026-06-09
 
 ### Added


### PR DESCRIPTION
ARC Pi runners fail npm ci during Docker build (exit 127 / Exit handler never called). Web is a static nginx image — safe to build on ubuntu-latest with QEMU arm64.

Made with [Cursor](https://cursor.com)