### PR TITLE
ci: drop version-check job (CD now via build-time tags)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
 
 jobs:
-  version-check:
-    name: VERSION Check
-    uses: raolivei/github-workflows/.github/workflows/version-check.yml@main
-
   web-e2e:
     name: Web E2E (Playwright)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Once raolivei/github-workflows#22 + raolivei/pi-fleet#TBD merge, FluxCD promotes by **build time**, not semver. VERSION bumps are no longer load-bearing for deployment, so the version-check gate is pure friction.

## What

Removes the ``version-check`` job from ``pr.yml``. ``VERSION`` and ``CHANGELOG.md`` remain in the repo as optional human-facing release markers.

## Supersedes

PR #213 (closed) — explicit ``content-paths`` + Dependabot removal split to its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)