### PR TITLE
ci: auto-bump version, drop version-check gate

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,6 +31,9 @@ jobs:
       image-name: swimto-api
       context: .
       dockerfile: apps/api/Dockerfile
+      # Auto-bump PATCH from the highest existing git tag on every push
+      # to main; mirror as ``v$VERSION`` git tag for traceability.
+      create-git-tag: true
     secrets:
       REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,5 +44,8 @@ jobs:
       context: ./apps/web
       # ARC Pi runners hit npm flake/timeouts; web is static nginx — build on GitHub-hosted.
       runs-on: ubuntu-latest
+      # Same auto-bump logic; the second job's git push is a no-op
+      # (the first job creates the tag, idempotency is built-in).
+      create-git-tag: true
     secrets:
       REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
 
 jobs:
-  version-check:
-    name: VERSION Check
-    uses: raolivei/github-workflows/.github/workflows/version-check.yml@main
-
   web-e2e:
     name: Web E2E (Playwright)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

CD via semver currently requires humans to bump ``VERSION`` on every PR. When forgotten, CI silently re-pushes the existing tag and Flux ignores it. Pair with raolivei/github-workflows#23, which adds auto-bump logic — every merge to ``main`` publishes ``vX.Y.Z+1`` automatically.

## What

- **``build-and-push.yml``**: pass ``create-git-tag: true`` to both ``docker-build.yml`` calls. This switches the version step into auto-bump mode and creates an annotated ``vX.Y.Z`` git tag on every release.
- **``pr.yml``**: remove the ``version-check`` job. Bumping is automated; the gate is pure friction now.

## How a routine merge looks now

1. Merge PR. CI runs.
2. Auto-bump computes next version: highest tag is ``v0.9.0`` (from this PR's first run after merge), bump to ``v0.9.1``.
3. CI tags image ``swimto-{api,web}:v0.9.1`` and pushes git tag ``v0.9.1``.
4. Flux's existing ``semver: '>=0.5.0 <1.0.0'`` ImagePolicy sees a new highest tag.
5. Flux's ImageUpdateAutomation promotes; cluster rolls.

No VERSION edit, no CHANGELOG required, no merge gate to fight.

When you actually want to bump MINOR or MAJOR (rare), edit ``VERSION`` to e.g. ``0.10.0`` in your PR — the auto-bump prefers the higher of (VERSION file, latest+patch).

## Test plan

- [ ] First merge after this lands publishes ``v0.9.1``, git tag ``v0.9.1`` appears, Flux promotes within 30 min.
- [ ] swimto.app shows ≥56 outdoor pools after the data-pipeline cron next runs (validates the v0.9.0 product changes finally take effect).
- [ ] PR-only changes (no merge) don't push image tags — ``create-git-tag`` is gated to ``push`` events on default branch.

## Note

Stray ``v1.0.0`` git tag (bot-created Dec 2025) was deleted from origin to keep auto-bump within Flux's semver range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)