### PR TITLE
fix(pipeline): unify Aquafit swim_type across drop-in and JSON parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Aquafit filter on /schedule only showed Norseman pool**: the two ingestion parsers were tagging the same activity differently — `data-pipeline/sources/toronto_drop_in_api.py` used `AQUAFIT` while `data-pipeline/sources/toronto_parks_json_api.py` and the frontend `SwimType` enum used `AQUATIC_FITNESS`. The drop-in parser now also writes `AQUATIC_FITNESS`, so aquafit sessions from every indoor pool surface under the "Aquatic Fitness" filter button. Existing rows can be relabeled with `UPDATE sessions SET swim_type = 'AQUATIC_FITNESS' WHERE swim_type = 'AQUAFIT';` (no-op on prod where the count is currently 0, but kept for completeness).
+
 ## [0.9.0] - 2026-06-21
 
 ### Added

--- a/data-pipeline/sources/toronto_drop_in_api.py
+++ b/data-pipeline/sources/toronto_drop_in_api.py
@@ -47,7 +47,12 @@ class TorontoDropInAPI:
             r'lane\s+swim', r'lap\s+swim', r'length\s+swim',
             r'adult\s+lane', r'senior\s+lane'
         ],
-        'AQUAFIT': [
+        # NOTE: keep this label aligned with the JSON parser
+        # (toronto_parks_json_api._classify_swim_type) and the frontend
+        # SwimType enum in apps/web/src/types/index.ts. Splitting "AQUAFIT"
+        # vs "AQUATIC_FITNESS" creates duplicate filter buttons in the UI
+        # and hides most pools' aquafit sessions from users.
+        'AQUATIC_FITNESS': [
             r'aqua\s*fit', r'water\s+fit', r'aqua\s*cise',
             r'aqua\s+aerobics', r'water\s+aerobics'
         ],


### PR DESCRIPTION
## Summary

On https://swimto.app/schedule, clicking the **Aquatic Fitness** filter only surfaced **Norseman Community School and Pool**, even though Toronto runs aquafit at most indoor pools. Root cause: the two ingestion parsers wrote different `swim_type` strings for the same activity, and the frontend filter only recognized one of them.

## Root cause

| Parser | Before | Where |
|---|---|---|
| `data-pipeline/sources/toronto_drop_in_api.py` (Toronto Open Data CSV — covers most indoor pools) | `AQUAFIT` | line 50 (key in `SWIM_TYPE_PATTERNS`) |
| `data-pipeline/sources/toronto_parks_json_api.py` (Parks JSON API — outdoor pools + Norseman) | `AQUATIC_FITNESS` | line 267 (`_classify_swim_type` return) |
| Frontend `SwimType` enum | recognises `AQUATIC_FITNESS` only | `apps/web/src/types/index.ts:41` |
| Frontend label/color tables | only have `AQUATIC_FITNESS` | `apps/web/src/lib/utils.ts:57,72,84` |

The schedule view builds filter buttons dynamically from `new Set(allSessions.map(s => s.swim_type))` (`apps/web/src/pages/ScheduleView.tsx:362`), so AQUAFIT rows would show up as a separate ghost button labelled with the raw constant; AQUATIC_FITNESS rows show up under "Aquatic Fitness" — and only Norseman ever produced those.

Live API confirmation (`https://swimto.app/api/schedule?swim_type=...&limit=1000`):

- `swim_type=AQUATIC_FITNESS` → 30 rows, 1 facility (Norseman)
- `swim_type=AQUAFIT` → 0 rows

## Fix

Standardise on `AQUATIC_FITNESS` (the value the frontend already supports) in the drop-in parser.

| Parser | After | Where |
|---|---|---|
| `data-pipeline/sources/toronto_drop_in_api.py` | `AQUATIC_FITNESS` | line 55 (key in `SWIM_TYPE_PATTERNS`) |
| `data-pipeline/sources/toronto_parks_json_api.py` | `AQUATIC_FITNESS` (unchanged) | line 267 |

Patterns in the drop-in parser are unchanged (`r'aqua\s*fit'`, `r'water\s+fit'`, `r'aqua\s*cise'`, `r'aqua\s+aerobics'`, `r'water\s+aerobics'`); only the bucket label moved.

## DB relabel for existing rows

Production currently has zero `AQUAFIT` rows so this is effectively a no-op there, but for any environment that may have accumulated some:

\`\`\`sql
UPDATE sessions SET swim_type = 'AQUATIC_FITNESS' WHERE swim_type = 'AQUAFIT';
\`\`\`

No alembic migration is added — the column is `String(50)` with no enum constraint, so a one-off statement suffices and won't conflict with existing migrations.

## Test plan

- [ ] After merge + next pipeline run, hit `GET /api/schedule?swim_type=AQUATIC_FITNESS&limit=1000` and confirm > 1 distinct facility (should include indoor pools beyond Norseman, e.g. Pam McConnell, North Toronto Memorial, etc.)
- [ ] On https://swimto.app/schedule, the "Aquatic Fitness" filter button should surface aquafit sessions across the city
- [ ] No "AQUAFIT" (raw, unlabeled) button appears in the filter row
- [ ] Existing filters (Lane Swim, Recreational, Adult, Senior) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)