### PR TITLE
fix(pipeline): match Toronto's actual aquafit/aquatic-fitness program…

### DIFF
--- a/data-pipeline/sources/toronto_drop_in_api.py
+++ b/data-pipeline/sources/toronto_drop_in_api.py
@@ -32,11 +32,17 @@ class TorontoDropInAPI:
     LOCATIONS_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca/datastore/dump/f23ac1ad-6f46-4b59-811f-eb34be9b1f7a"
     FACILITIES_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca/datastore/dump/e16505dc-f106-4b58-a689-ed0a2b8b0b69"
     
-    # Swim activity keywords to filter drop-in programs
+    # Swim activity keywords to filter drop-in programs.
+    # NOTE: Toronto's actual Open Data CSV uses "Aquatic Fitness: ..." as the
+    # Course Title prefix (e.g. "Aquatic Fitness: Shallow", "Aquatic Fitness:
+    # Deep"). The colloquial "Aquafit"/"Aqua Fit" terms are kept for
+    # forward-compat in case Toronto changes the label, but "aquatic fitness"
+    # is what the live feed actually emits.
     SWIM_KEYWORDS = [
         'lane swim', 'lane swimming', 'lap swim', 'lap swimming',
         'leisure swim', 'recreational swim', 'family swim',
-        'adult swim', 'senior swim', 'aquafit', 'aqua fit',
+        'adult swim', 'senior swim',
+        'aquatic fitness', 'aquafit', 'aqua fit',
         'water fit', 'aquacise', 'aqua aerobics',
         'public swim', 'open swim', 'drop-in swim'
     ]
@@ -53,6 +59,7 @@ class TorontoDropInAPI:
         # vs "AQUATIC_FITNESS" creates duplicate filter buttons in the UI
         # and hides most pools' aquafit sessions from users.
         'AQUATIC_FITNESS': [
+            r'aquatic\s+fitness',
             r'aqua\s*fit', r'water\s+fit', r'aqua\s*cise',
             r'aqua\s+aerobics', r'water\s+aerobics'
         ],


### PR DESCRIPTION
… titles

The Toronto Open Data drop-in CSV uses "Aquatic Fitness: ..." as the Course Title prefix (e.g. "Aquatic Fitness: Shallow", "Aquatic Fitness: Deep"). Our keyword filter only had "aquafit" / "aqua fit", neither of which prefix-matches "aquatic fitness", so 1,702 aquafit rows across 48 indoor pools were dropped before they ever reached the classifier. The classifier regex (r'aqua\s*fit') also fails to match because "aquatic" inserts "tic " between "aqua" and "fit".

Add "aquatic fitness" to SWIM_KEYWORDS and r'aquatic\s+fitness' to the AQUATIC_FITNESS pattern list. Verified against live CSV: 0 → 1,702 AQUATIC_FITNESS rows, distributed across 48 facilities, no regressions in LANE_SWIM / RECREATIONAL counts.

Stacks on top of #216 (AQUAFIT/AQUATIC_FITNESS label unification), which must be merged first.