### PR TITLE
fix(pipeline): match Toronto's actual aquafit/aquatic-fitness program titles

### DIFF
--- a/data-pipeline/sources/toronto_drop_in_api.py
+++ b/data-pipeline/sources/toronto_drop_in_api.py
@@ -32,11 +32,17 @@ class TorontoDropInAPI:
     LOCATIONS_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca/datastore/dump/f23ac1ad-6f46-4b59-811f-eb34be9b1f7a"
     FACILITIES_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca/datastore/dump/e16505dc-f106-4b58-a689-ed0a2b8b0b69"
     
-    # Swim activity keywords to filter drop-in programs
+    # Swim activity keywords to filter drop-in programs.
+    # NOTE: Toronto's actual Open Data CSV uses "Aquatic Fitness: ..." as the
+    # Course Title prefix (e.g. "Aquatic Fitness: Shallow", "Aquatic Fitness:
+    # Deep"). The colloquial "Aquafit"/"Aqua Fit" terms are kept for
+    # forward-compat in case Toronto changes the label, but "aquatic fitness"
+    # is what the live feed actually emits.
     SWIM_KEYWORDS = [
         'lane swim', 'lane swimming', 'lap swim', 'lap swimming',
         'leisure swim', 'recreational swim', 'family swim',
-        'adult swim', 'senior swim', 'aquafit', 'aqua fit',
+        'adult swim', 'senior swim',
+        'aquatic fitness', 'aquafit', 'aqua fit',
         'water fit', 'aquacise', 'aqua aerobics',
         'public swim', 'open swim', 'drop-in swim'
     ]
@@ -53,6 +59,7 @@ class TorontoDropInAPI:
         # vs "AQUATIC_FITNESS" creates duplicate filter buttons in the UI
         # and hides most pools' aquafit sessions from users.
         'AQUATIC_FITNESS': [
+            r'aquatic\s+fitness',
             r'aqua\s*fit', r'water\s+fit', r'aqua\s*cise',
             r'aqua\s+aerobics', r'water\s+aerobics'
         ],


### PR DESCRIPTION
## Summary

The Toronto Open Data drop-in CSV uses **"Aquatic Fitness: ..."** as the
`Course Title` prefix. Our `SWIM_KEYWORDS` filter only contained
`aquafit` / `aqua fit`, neither of which substring-matches
`"aquatic fitness"`, so **every aquafit session at every indoor pool was
silently dropped** at filter time. The classification regex
`r'aqua\s*fit'` also fails to match because the literal `tic ` between
`aqua` and `fit` is not whitespace.

Result on prod (`https://swimto.app/api/schedule?swim_type=AQUATIC_FITNESS`):
- **Before:** 30 rows, all from Norseman (only the JSON parser produced rows; CSV parser produced zero).
- **Live CSV under fix:** 1,702 AQUATIC_FITNESS rows across 48 distinct facilities (Pam McConnell, Regent Park, Harrison, Trinity, Giovanni Caboto, etc.).

## Stack note

This stacks on top of #216 (AQUAFIT/AQUATIC_FITNESS label unification),
which must be merged first. Branched off `origin/main` so it'll rebase
cleanly once #216 lands.

## Root cause

`is_swim_activity()` does an `any(keyword in text for keyword in SWIM_KEYWORDS)` substring check.
Toronto's titles look like `Aquatic Fitness: Shallow`, `Aquatic Fitness: Deep`, `Aquatic Fitness: Walking`, etc. — none of the existing keywords substring-match these strings, so the rows were filtered out before classification.

Sample of distinct Course Title strings from the live CSV (5 of 11):
- `Aquatic Fitness: Shallow` (1,057 rows)
- `Aquatic Fitness: Deep` (154 rows)
- `Aquatic Fitness: Arthritis` (241 rows)
- `Aquatic Fitness: Walking` (91 rows)
- `Aquatic Fitness: Boot Camp` (77 rows)

(Also: `Aquatic Fitness: Mind Body`, `Aquatic Fitness: Kickboxing`, `Aquatic Fitness: Circuit Training`, `Aquatic Fitness: Shallow (Women)`, `Aquatic Fitness: Deep (Women)`, `Aquatic Fitness: Shallow (Giovanni Caboto)`.)

## Changes

`data-pipeline/sources/toronto_drop_in_api.py`:

1. Added `'aquatic fitness'` to `SWIM_KEYWORDS` so `is_swim_activity()` keeps these rows.
2. Added `r'aquatic\s+fitness'` to `SWIM_TYPE_PATTERNS['AQUATIC_FITNESS']` so `classify_swim_type()` returns the right label.
3. Added a comment explaining why we keep both `aquatic fitness` (what the feed actually says) and `aquafit`/`aqua fit` (forward-compat).

Old colloquial keywords (`aquafit`, `aqua fit`, `water fit`, `aquacise`, `aqua aerobics`, `water aerobics`) are intentionally retained for resilience to future Toronto label changes.

## Live CSV verification

Filter logic, run against today's `c99ec04f-...` CSV:

```
Total CSV rows                          : 31,928
filter_swim_activities() BEFORE fix     : 10,987
filter_swim_activities() AFTER fix      : 12,689   (+1,702)
AQUATIC_FITNESS rows BEFORE fix         : 0
AQUATIC_FITNESS rows AFTER fix          : 1,702
Distinct facilities w/ AQUATIC_FITNESS  : 48
```

Distribution of swim_type after fix (no LANE_SWIM/RECREATIONAL regressions):
```
LANE_SWIM            5,567
RECREATIONAL         5,420
AQUATIC_FITNESS      1,702
```

Spot-check confirms only legitimate "Aquatic Fitness: ..." titles get the AQUATIC_FITNESS label — no false positives from `Functional Fit`, `Gentle Fit`, `Water Play`, etc.

## Test plan

- [x] Pulled live CKAN CSV; confirmed 1,702 "Aquatic Fitness: ..." rows across 48 distinct `Location ID`s.
- [x] Replayed `is_swim_activity()` and `classify_swim_type()` against the full live CSV: 0 → 1,702 AQUATIC_FITNESS rows captured.
- [x] Verified no regression on existing buckets (LANE_SWIM 5,567, RECREATIONAL 5,420).
- [x] Verified no false positives — every distinct title bucketed into AQUATIC_FITNESS starts with `Aquatic Fitness:`.
- [ ] After merge of #216 + this PR, re-run `curl https://swimto.app/api/schedule?swim_type=AQUATIC_FITNESS&limit=1000 | jq length` — expect a count well above the 30 baseline (anticipated >1,000 once next ingestion run completes).
- [ ] Post-deploy: spot-check a few indoor pools (Pam McConnell, Regent Park, Harrison) in the UI for AQUATIC_FITNESS sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)