### PR TITLE
test(web): fix flaky mobile leaflet-marker visibility wait

### DIFF
--- a/apps/web/src/tests/map-panel.spec.ts
+++ b/apps/web/src/tests/map-panel.spec.ts
@@ -9,7 +9,23 @@ test.describe("Map facility panel", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/map");
     await page.waitForSelector(".leaflet-container", { timeout: 20000 });
-    await page.waitForSelector("path.leaflet-interactive", { timeout: 20000 });
+    // Leaflet renders ``path.leaflet-interactive`` elements with
+    // ``d="M0 0"`` before the initial fitBounds completes. Playwright's
+    // visibility check then fails (zero-size = not visible) and on a
+    // narrow mobile viewport in CI the fitBounds animation can run
+    // longer than 20s. Wait for the *first non-zero* path instead so
+    // we're guarded against that race rather than racing against it.
+    await page.waitForFunction(
+      () =>
+        Array.from(
+          document.querySelectorAll<SVGPathElement>("path.leaflet-interactive")
+        ).some((p) => {
+          const d = p.getAttribute("d") || "";
+          return d.length > 0 && d !== "M0 0";
+        }),
+      undefined,
+      { timeout: 30000 }
+    );
   });
 
   test("desktop: panel stays visible after selecting a marker", async ({ page }) => {
@@ -18,7 +34,9 @@ test.describe("Map facility panel", () => {
       "Desktop-only panel positioning test"
     );
 
-    const markers = page.locator("path.leaflet-interactive");
+    const markers = page.locator(
+      'path.leaflet-interactive:not([d="M0 0"])'
+    );
     const count = await markers.count();
     expect(count).toBeGreaterThan(0);
 
@@ -65,7 +83,9 @@ test.describe("Map facility panel", () => {
       "Mobile-only panel test"
     );
 
-    const markers = page.locator("path.leaflet-interactive");
+    const markers = page.locator(
+      'path.leaflet-interactive:not([d="M0 0"])'
+    );
     await markers.first().click({ force: true });
 
     const panel = page.getByTestId("facility-panel-mobile");


### PR DESCRIPTION
## Why

PR #219's CI run failed [9 of 12 mobile tests](https://github.com/raolivei/swimTO/actions/runs/27909702076/job/82584586668?pr=219) with the same timeout in ``beforeEach``:

\`\`\`
TimeoutError: page.waitForSelector: Timeout 20000ms exceeded.
- waiting for locator('path.leaflet-interactive') to be visible
- 45 × locator resolved to 29 elements. Proceeding with the first one:
  <path d="M0 0" stroke="white" fill="#9ca3af" ...>
\`\`\`

Leaflet renders SVG marker paths with ``d="M0 0"`` until the initial fitBounds animation completes. They exist in the DOM (locator finds 29) but Playwright's visibility check fails (zero-size = not visible). On a 393×851 Pixel 5 viewport in CI, that animation runs longer than 20s, so the suite fails before any test logic runs. Chromium-desktop passes because its animation completes in ~200ms.

## What

\`\`\`diff
- await page.waitForSelector("path.leaflet-interactive", { timeout: 20000 });
+ await page.waitForFunction(
+   () => Array.from(document.querySelectorAll<SVGPathElement>("path.leaflet-interactive"))
+     .some((p) => { const d = p.getAttribute("d") || ""; return d.length > 0 && d !== "M0 0"; }),
+   undefined, { timeout: 30000 }
+ );
\`\`\`

Plus the per-test marker locator now filters with ``path.leaflet-interactive:not([d="M0 0"])`` so any ``markers.first()`` / ``markers.nth(i)`` call skips placeholder paths.

## Verified locally

\`\`\`
$ npx playwright test src/tests/map-panel.spec.ts --config=playwright.ci.config.ts --project=chromium
  2 passed (6.0s)

$ npx playwright test src/tests/map-panel.spec.ts --config=playwright.ci.config.ts --project=mobile
  ✓ mobile: panel visible after selecting a marker (793ms)
  ✓ pool type filter requests outdoor from API (3.3s)
  2 passed (4.6s)
\`\`\`

Mobile suite went from 21s × 3-retry timeouts to under 5s end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)