### PR TITLE
chore(ops): weekly discover-facilities CronJob (closes #183)

### DIFF
--- a/k8s/cronjob-discover.yaml
+++ b/k8s/cronjob-discover.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: swimto-discover-facilities
+  namespace: swimto
+spec:
+  # Run weekly on Mondays at 6 AM Toronto time (11:00 UTC)
+  schedule: "0 11 * * 1"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: swimto-discover-facilities
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: discover
+              image: ghcr.io/raolivei/swimto-api:v0.5.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  REPORT=/tmp/discovery_report.json
+                  python /data-pipeline/jobs/discover_swim_facilities.py \
+                    --pool-type all \
+                    --out "$REPORT"
+                  python - <<'PY'
+                  import json, os
+                  from loguru import logger
+                  from sqlalchemy import create_engine, text
+
+                  report_path = "/tmp/discovery_report.json"
+                  with open(report_path) as f:
+                      report = json.load(f)
+
+                  swim_active = [
+                      loc for loc in report.get("locations", [])
+                      if loc.get("schedule_source") != "no_programs"
+                  ]
+
+                  db_url = os.environ["DATABASE_URL"]
+                  engine = create_engine(db_url)
+                  with engine.connect() as conn:
+                      rows = conn.execute(
+                          text("SELECT toronto_location_id FROM facilities WHERE toronto_location_id IS NOT NULL")
+                      ).fetchall()
+                      known = {str(r[0]) for r in rows}
+
+                  unknown = [
+                      loc for loc in swim_active
+                      if str(loc.get("location_id")) not in known
+                  ]
+
+                  if unknown:
+                      logger.warning(
+                          f"Found {len(unknown)} swim-active location(s) NOT in DB: "
+                          + ", ".join(
+                              f"{loc.get('location_id')} ({loc.get('name') or 'unknown'})"
+                              for loc in unknown
+                          )
+                      )
+                  else:
+                      logger.info(
+                          f"All {len(swim_active)} swim-active location(s) already known in DB."
+                      )
+                  PY
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: swimto-secrets
+                      key: DATABASE_URL
+              envFrom:
+                - configMapRef:
+                    name: swimto-config
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"


### PR DESCRIPTION
## Summary
- Adds `k8s/cronjob-discover.yaml`: a weekly CronJob that runs `data-pipeline/jobs/discover_swim_facilities.py` against Toronto Open Data so we get notified when the City publishes new swim-active locations.
- Schedule: `0 11 * * 1` (Mondays 06:00 America/Toronto = 11:00 UTC). Cluster CronJobs run in UTC, so the schedule is committed in UTC.
- Same image, secret (`swimto-secrets`/`DATABASE_URL`), and ConfigMap (`swimto-config`) as the existing daily refresh CronJob.
- After the discovery report is written to `/tmp/discovery_report.json`, an inline Python tail-step queries the `facilities` table for known `toronto_location_id`s and emits `logger.warning(...)` listing any swim-active locations (`schedule_source != "no_programs"`) that aren't yet in the DB. No data-pipeline source code is modified.
- `concurrencyPolicy: Forbid`, `backoffLimit: 2`, `restartPolicy: Never`, history limits 3/3 — same hardening as `facility-url-validator`.

Closes #183.

## GitOps note
The actual cluster source of truth is `pi-fleet/clusters/eldertree/swimto/`. A matching manifest plus kustomization wire-up needs to land in pi-fleet (`feat/swimto-discover-cronjob`) for Flux to apply this. The manifest in this repo is the in-repo reference copy that mirrors `k8s/cronjob-refresh.yaml`.

## Test plan
- [ ] Land matching `cronjob-discover.yaml` in pi-fleet under `clusters/eldertree/swimto/` with `imagePullSecrets: ghcr-secret` and the `$imagepolicy` marker, and add it to `kustomization.yaml`.
- [ ] After Flux reconciles: `kubectl -n swimto get cronjob swimto-discover-facilities`
- [ ] Manual trigger to validate end-to-end before the first scheduled run: `kubectl -n swimto create job --from=cronjob/swimto-discover-facilities swimto-discover-manual`
- [ ] Inspect logs: `kubectl -n swimto logs job/swimto-discover-manual` — expect either `Found N swim-active location(s) NOT in DB: ...` (warning) or `All N swim-active location(s) already known in DB.` (info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)