### PR TITLE
fix(pipeline): match drop-in programs by location_id (closes #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Drop-in program facility matching (#181)**: `TorontoDropInAPI.match_facility` now resolves drop-in programs to facilities by `toronto_location_id` (integer) before falling back to name-based fuzzy matching. The curated facilities ingest in `daily_refresh` already persists this column (migration 004), but the schedule ingest still relied on fuzzy name matching, producing spurious "no match" warnings whenever the curated name differed by punctuation/suffix from the Open Data label. Backward-compatible: legacy facilities without a `toronto_location_id` still match by name. New `Matched by toronto_location_id=...` info log fires per matched program so the new path is visible in prod logs.
 - **Aquafit filter on /schedule only showed Norseman pool**: the two ingestion parsers were tagging the same activity differently — `data-pipeline/sources/toronto_drop_in_api.py` used `AQUAFIT` while `data-pipeline/sources/toronto_parks_json_api.py` and the frontend `SwimType` enum used `AQUATIC_FITNESS`. The drop-in parser now also writes `AQUATIC_FITNESS`, so aquafit sessions from every indoor pool surface under the "Aquatic Fitness" filter button. Existing rows can be relabeled with `UPDATE sessions SET swim_type = 'AQUATIC_FITNESS' WHERE swim_type = 'AQUAFIT';` (no-op on prod where the count is currently 0, but kept for completeness).
 
 ## [0.9.0] - 2026-06-21

--- a/data-pipeline/sources/toronto_drop_in_api.py
+++ b/data-pipeline/sources/toronto_drop_in_api.py
@@ -474,15 +474,43 @@ class TorontoDropInAPI:
     ) -> Optional[str]:
         """
         Match a location from the API to an existing facility in our database.
-        
+
+        Resolution order:
+        1. Exact match on ``Facility.toronto_location_id`` (authoritative;
+           populated by the curated facility ingest in ``daily_refresh``).
+        2. Exact case-insensitive name match.
+        3. Fuzzy name match.
+        4. Postal-code match via ``location_data``.
+
         Returns facility_id if match found, None otherwise.
         """
+        # 1. Primary key: toronto_location_id (integer match).
+        # Curated facilities (see toronto_pools_data.py) carry the same
+        # Location ID Toronto's Open Data uses, so this should be the common
+        # path. Legacy facilities without a toronto_location_id still fall
+        # through to the fuzzy name logic below.
+        if location_id:
+            try:
+                location_id_int = int(str(location_id).strip())
+            except (ValueError, TypeError):
+                location_id_int = None
+
+            if location_id_int is not None:
+                for facility in existing_facilities:
+                    facility_loc_id = getattr(facility, 'toronto_location_id', None)
+                    if facility_loc_id is not None and facility_loc_id == location_id_int:
+                        logger.info(
+                            f"Matched by toronto_location_id={location_id_int}: "
+                            f"'{location_name}' -> '{facility.name}'"
+                        )
+                        return facility.facility_id
+
         if not location_name:
             return None
-        
+
         location_name_lower = location_name.lower().strip()
-        
-        # Try exact match first
+
+        # 2. Exact case-insensitive name match
         for facility in existing_facilities:
             if facility.name.lower().strip() == location_name_lower:
                 return facility.facility_id


### PR DESCRIPTION
## Summary

- `TorontoDropInAPI.match_facility` now resolves drop-in programs to facilities by `Facility.toronto_location_id` (integer) before falling back to name-based matching, eliminating the spurious "unmatched location" warnings flagged in #181.
- Backward-compatible: legacy facilities without a `toronto_location_id` (e.g. `pools_xml`-only rows) still match by exact name → fuzzy → postal code as before.
- Adds a `Matched by toronto_location_id=N: 'X' -> 'Y'` info log per matched program so the new path is visible in prod logs.

## Why

Migration 004 (already in `main`) added `Facility.toronto_location_id` and `seed_facilities` / `ingest_curated_facilities` persist it from the curated `toronto_pools_data` list. But `ingest_official_schedules` in `daily_refresh.py` was still calling the name-based fuzzy matcher — so identical Location IDs on both sides could fail to match whenever the curated name differed from Toronto's Open Data label (punctuation, suffix variants, etc.).

## Resolution order (after this change)

1. Exact integer match on `Facility.toronto_location_id` (new — primary)
2. Exact case-insensitive name match
3. Fuzzy name match (legacy)
4. Postal-code match (legacy)

## Verification (no live DB ingest)

Pulled the live drop-in CSV (`DROP_IN_PROGRAMS_URL`) and traced 3 curated `toronto_location_id`s through the new logic:

| Location ID | Curated facility                                | Swim rows in CSV |
|------------:|--------------------------------------------------|-----------------:|
| 189         | North Toronto Memorial Community Centre          | 239              |
| 31          | Ourland Park Outdoor Pool                        | 44               |
| 502         | Fairbank Memorial Park                           | 64               |

For each, `int("189".strip()) == 189` (etc.) hits step 1 immediately and returns the matching `facility_id`. The fuzzy fallback path is unchanged for facilities that don't carry a `toronto_location_id`.

## Test plan

- [ ] Next scheduled `daily-refresh` job in prod logs `Matched by toronto_location_id=...` lines for the 50+ curated facilities and the "Unmatched locations" warning count drops materially.
- [ ] Sessions table count for the 3 verified facilities (189, 31, 502) is non-zero after the next refresh.
- [ ] No regressions for facilities that lack `toronto_location_id` (e.g. legacy `pools_xml` rows) — they still resolve via the existing name-based path.

Closes #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)