### PR TITLE
docs: promote [Unreleased] → [0.9.1] for the auto-bumped release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-21
+
 ### Added
 
 - **Why-swimTO advantages section on the homepage** ([#219]): three-card grid (Database / RefreshCw / Waves icons) under a new "Skip the runaround." headline summarising what swimTO does — aggregates every Toronto drop-in swim, sources kept fresh automatically from the City Open Data Portal, indoor + outdoor coverage.


### PR DESCRIPTION
## Why

#226 merged and CI auto-bumped to ``v0.9.1`` (git tag pushed, images tagged), but the CHANGELOG still said ``[Unreleased]``. Heading drifted out of sync with the tag.

## What

One-line edit: rename the top ``[Unreleased]`` to ``[0.9.1] - 2026-06-21``. A new empty ``[Unreleased]`` stays above it for the next release's notes.

## Follow-up (separate PR)

Wire this rename into the docker-build workflow so ``[Unreleased]`` → ``[<version>] - <date>`` happens automatically whenever auto-bump fires. Same place, same commit as the auto-bumped git tag, same idempotency guarantees. After that, manual changelog discipline is no longer load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)