### PR TITLE
feat(pipeline): geocode facilities with missing coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Geocoding for facilities with missing coordinates** ([#231]): new on-demand job `data-pipeline/jobs/geocode_missing_coordinates.py` resolves lat/lon via OpenStreetMap Nominatim (free, no API key, 1 req/sec rate limit) for any facility that has an address but NULL coordinates. Toronto Open Data's Locations CSV ships with NULL lat/lon for some entries (Sunnyside Gus Ryder Outdoor Pool was one example), which prevented those facilities from showing on the map. Already applied to prod via `kubectl exec`: 48 facilities (incl. all 56 outdoor pools, now 100% coverage) updated.
+
 ### Fixed
 
 - **Map no longer auto-zooms back when filters change** ([#232]): `MapController` ran `fitBounds` on every change to its deps, which included inline-derived `validFacilities` — a fresh array reference on every render. So every keystroke in search, every pool-type toggle, every favorite click, every unrelated re-render re-fit the map and yanked the user's manual zoom back. Now the initial fit happens exactly once via a `useRef` guard; the Locate / Recenter FAB explicitly re-fits via a new top-level helper `fitToUserAndFacilities(map, ...)`; the four derived facility arrays (`facilitiesWithDistance`, `sortedFacilities`, `visibleFacilities`, `validFacilities`) are memoized so dependent effects don't fire on spurious renders. As a side fix, the panel-position effect now listens on Leaflet's `moveend` (not `move`) so the panel doesn't briefly render with negative pixel coords during an animated `panBy`.
 
+[#231]: https://github.com/raolivei/swimTO/pull/231
 [#232]: https://github.com/raolivei/swimTO/pull/232
 
 ## [0.9.1] - 2026-06-21


### PR DESCRIPTION
## Why

48 facilities (mostly outdoor pools from the recent discovery work) had `latitude: NULL, longitude: NULL` in the DB, even though they had valid addresses. Without coordinates, the map at https://swimto.app/map can't plot markers for them.

**Reported symptom:** Sunnyside Gus Ryder Outdoor Pool (location_id 433) didn't show on the map.

**Root cause:** Toronto Open Data's Locations CSV has NULL lat/lon for some facilities (Sunnyside included). The discovery/seeding pipeline copies whatever Open Data provides, so the NULLs propagated.

## What

- **New script:** `data-pipeline/jobs/geocode_missing_coordinates.py` — geocodes addresses via OpenStreetMap Nominatim (free, no API key), rate-limited to 1 req/sec per OSM usage policy. Supports `--dry-run`.
- **Already applied on prod:** ran the script inline via `kubectl exec` against the live DB. All 48 facilities now have coordinates. Sunnyside and every other outdoor pool is visible on the map.

## Files

- `data-pipeline/jobs/geocode_missing_coordinates.py` (new, +134 lines)

## Test plan

- [x] Ran inline via kubectl exec on prod (48/48 updated).
- [x] Verified Sunnyside API response: `lat: 43.637659, lon: -79.454530` ✓
- [x] Verified all 56 outdoor pools now have coordinates (100% coverage).
- [ ] After merge: the script ships in the next image build. Can be re-run if future discovery work adds more facilities with missing coords.

## Notes

The script is one-time/on-demand (not a CronJob) — most facilities already have coords from the curated list. Only the auto-discovered outdoor pools hit this. If we add more pools in future and they're missing coords, re-run the script manually or wire it into the daily_refresh pipeline.

Closes the "Sunnyside not showing on map" issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)