### PR TITLE
feat(web): schedule pool filter, grouped list, fix nearest sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Indoor/outdoor pool filter on schedule page**: All / Indoor / Outdoor segmented control on `/schedule`, matching the map page. Client-side filter uses `has_indoor` / `has_outdoor` on each session's facility. Shared `PoolTypeFilterControl` component extracted from `MapView`; selection persisted in `localStorage` so schedule and map stay in sync.
+- **Grouped list view on desktop schedule**: List view now groups sessions by community center on all screen sizes (same pattern as mobile since v0.7.5). One facility card shows multiple time slots in a responsive 2–4 column grid; pool-type badge on facility header; share action per slot on desktop.
+
 - **Automatic SQL migrations on api startup** ([#229]): new `app/migrate.py` runner applies any pending `apps/api/migrations/NNN_*.sql` files against the live database before uvicorn starts. Tracks applied versions in a `schema_migrations` table; backfills the table on first run by inspecting marker columns so existing prod DBs (where migrations were applied manually) don't try to re-run. Migration files moved from `scripts/migrations/` into `apps/api/migrations/` so they ship inside the api image. Dockerfile no longer silently swallows migration failures (`alembic upgrade head 2>/dev/null || true` is gone) — a failure now aborts pod start. Closes the class of incident that broke v0.9.1's API for ~24 hours when migration 004 was committed but never ran on prod.
 - **Geocoding for facilities with missing coordinates** ([#231]): new on-demand job `data-pipeline/jobs/geocode_missing_coordinates.py` resolves lat/lon via OpenStreetMap Nominatim (free, no API key, 1 req/sec rate limit) for any facility that has an address but NULL coordinates. Toronto Open Data's Locations CSV ships with NULL lat/lon for some entries (Sunnyside Gus Ryder Outdoor Pool was one example), which prevented those facilities from showing on the map. Already applied to prod via `kubectl exec`: 48 facilities (incl. all 56 outdoor pools, now 100% coverage) updated.
 
@@ -25,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Schedule nearest sort order** — facilities with “happening now” sessions no longer jump ahead of closer pools when Nearest sort is active; distance sort is strictly numeric ascending. Happening-now boost applies only when that filter is explicitly enabled (and not in Nearest mode).
 - **Map no longer auto-zooms back when filters change** ([#232]): `MapController` ran `fitBounds` on every change to its deps, which included inline-derived `validFacilities` — a fresh array reference on every render. So every keystroke in search, every pool-type toggle, every favorite click, every unrelated re-render re-fit the map and yanked the user's manual zoom back. Now the initial fit happens exactly once via a `useRef` guard; the Locate / Recenter FAB explicitly re-fits via a new top-level helper `fitToUserAndFacilities(map, ...)`; the four derived facility arrays (`facilitiesWithDistance`, `sortedFacilities`, `visibleFacilities`, `validFacilities`) are memoized so dependent effects don't fire on spurious renders. As a side fix, the panel-position effect now listens on Leaflet's `moveend` (not `move`) so the panel doesn't briefly render with negative pixel coords during an animated `panBy`.
 
 [#231]: https://github.com/raolivei/swimTO/pull/231

--- a/apps/web/src/components/PoolTypeFilterControl.tsx
+++ b/apps/web/src/components/PoolTypeFilterControl.tsx
@@ -1,0 +1,73 @@
+import { MapPin, Sun, Building2 } from "lucide-react";
+import type { PoolTypeFilter } from "../lib/api";
+
+const POOL_TYPE_OPTIONS: {
+  value: PoolTypeFilter;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  { value: "all", label: "All", icon: MapPin },
+  { value: "indoor", label: "Indoor", icon: Building2 },
+  { value: "outdoor", label: "Outdoor", icon: Sun },
+];
+
+export function PoolTypeFilterControl({
+  value,
+  onChange,
+  testId = "map-pool-type-filter",
+  className = "",
+  showHint = true,
+  label,
+}: {
+  value: PoolTypeFilter;
+  onChange: (next: PoolTypeFilter) => void;
+  testId?: string;
+  className?: string;
+  showHint?: boolean;
+  label?: string;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className={`flex flex-col gap-1.5 ${className}`}
+    >
+      {label && (
+        <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 px-1">
+          {label}
+        </span>
+      )}
+      {showHint && (
+        <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 px-1 hidden sm:block">
+          Outdoor pools open for summer
+        </p>
+      )}
+      <div
+        role="group"
+        aria-label="Pool type filter"
+        className="flex bg-white dark:bg-gray-800 rounded-full shadow-md border border-gray-200 dark:border-gray-700 p-1"
+      >
+        {POOL_TYPE_OPTIONS.map(({ value: option, label, icon: Icon }) => {
+          const active = value === option;
+          return (
+            <button
+              key={option}
+              type="button"
+              data-testid={`pool-type-${option}`}
+              onClick={() => onChange(option)}
+              className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-semibold transition-colors min-h-[40px] ${
+                active
+                  ? option === "outdoor"
+                    ? "bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200"
+                    : "bg-primary-100 dark:bg-primary-900/50 text-primary-800 dark:text-primary-200"
+                  : "text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
+              }`}
+            >
+              <Icon className="w-3.5 h-3.5" />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/usePoolTypeFilter.ts
+++ b/apps/web/src/hooks/usePoolTypeFilter.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react";
+import type { PoolTypeFilter } from "../lib/api";
+
+const STORAGE_KEY = "swimto_pool_type";
+
+function readStoredPoolType(): PoolTypeFilter {
+  if (typeof window === "undefined") return "all";
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "indoor" || stored === "outdoor" || stored === "all") {
+    return stored;
+  }
+  return "all";
+}
+
+/** Shared indoor/outdoor filter — persisted across schedule and map. */
+export function usePoolTypeFilter(): [PoolTypeFilter, (next: PoolTypeFilter) => void] {
+  const [poolType, setPoolTypeState] = useState<PoolTypeFilter>(readStoredPoolType);
+
+  const setPoolType = useCallback((next: PoolTypeFilter) => {
+    setPoolTypeState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  }, []);
+
+  return [poolType, setPoolType];
+}

--- a/apps/web/src/lib/facilitySort.test.ts
+++ b/apps/web/src/lib/facilitySort.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { compareFacilityGroups } from "./facilitySort";
+import type { Facility, Session } from "../types";
+
+const userLocation = { latitude: 43.6532, longitude: -79.3832 };
+
+const nearFacility = {
+  facility_id: "near",
+  name: "Near Pool",
+  address: null,
+  postal_code: null,
+  latitude: 43.66,
+  longitude: -79.38,
+  is_free_entry: false,
+  website: null,
+  district: null,
+  is_indoor: true,
+  phone: null,
+  source: null,
+  created_at: "",
+  updated_at: "",
+} satisfies Facility;
+
+const farFacility = {
+  facility_id: "far",
+  name: "Far Pool",
+  address: null,
+  postal_code: null,
+  latitude: 43.9,
+  longitude: -79.5,
+  is_free_entry: false,
+  website: null,
+  district: null,
+  is_indoor: true,
+  phone: null,
+  source: null,
+  created_at: "",
+  updated_at: "",
+} satisfies Facility;
+
+const dummySession = (facility: Facility): Session => ({
+  id: 1,
+  facility_id: facility.facility_id,
+  swim_type: "LANE_SWIM",
+  date: "2026-06-23",
+  start_time: "12:00",
+  end_time: "13:00",
+  notes: null,
+  age_min: null,
+  age_max: null,
+  source: null,
+  created_at: "",
+  facility,
+});
+
+describe("compareFacilityGroups", () => {
+  it("sorts by ascending distance in nearest mode", () => {
+    const result = compareFacilityGroups(
+      { facility: farFacility, distance: 30, sessions: [dummySession(farFacility)] },
+      { facility: nearFacility, distance: 1, sessions: [dummySession(nearFacility)] },
+      {
+        sortMode: "distance",
+        userLocation,
+        isFavorite: () => false,
+        prioritizeHappeningNow: false,
+        isHappeningNow: () => true, // must not override nearest mode
+      }
+    );
+    expect(result).toBeGreaterThan(0); // far after near
+  });
+
+  it("does not let happening-now override nearest mode", () => {
+    const result = compareFacilityGroups(
+      { facility: farFacility, distance: 30, sessions: [dummySession(farFacility)] },
+      { facility: nearFacility, distance: 1, sessions: [dummySession(nearFacility)] },
+      {
+        sortMode: "distance",
+        userLocation,
+        isFavorite: () => false,
+        prioritizeHappeningNow: true,
+        isHappeningNow: (s) => s.facility_id === "far",
+      }
+    );
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("boosts happening-now only when filter is on and not in nearest mode", () => {
+    const result = compareFacilityGroups(
+      { facility: farFacility, distance: 30, sessions: [dummySession(farFacility)] },
+      { facility: nearFacility, distance: 1, sessions: [dummySession(nearFacility)] },
+      {
+        sortMode: "favorites",
+        userLocation,
+        isFavorite: () => false,
+        prioritizeHappeningNow: true,
+        isHappeningNow: (s) => s.facility_id === "far",
+      }
+    );
+    expect(result).toBeLessThan(0); // far (happening now) before near
+  });
+});

--- a/apps/web/src/lib/facilitySort.ts
+++ b/apps/web/src/lib/facilitySort.ts
@@ -1,0 +1,108 @@
+import { calculateDistance, type UserLocation } from "./utils";
+import type { Facility, Session } from "../types";
+
+export type FacilitySortMode = "distance" | "favorites";
+
+export interface FacilityGroupSortInput {
+  facility?: Facility | null;
+  distance?: number;
+  sessions: Session[] | Record<string, Session[]>;
+}
+
+function flatSessions(
+  sessions: Session[] | Record<string, Session[]>
+): Session[] {
+  return Array.isArray(sessions) ? sessions : Object.values(sessions).flat();
+}
+
+/** Distance in km — uses cached value or recomputes from facility coordinates. */
+export function facilityDistanceKm(
+  facility: Facility | null | undefined,
+  userLocation: UserLocation | null,
+  cached?: number
+): number | undefined {
+  if (cached !== undefined) return cached;
+  if (
+    !userLocation ||
+    facility?.latitude == null ||
+    facility?.longitude == null
+  ) {
+    return undefined;
+  }
+  return calculateDistance(
+    userLocation.latitude,
+    userLocation.longitude,
+    facility.latitude,
+    facility.longitude
+  );
+}
+
+export function compareFacilityGroups(
+  a: FacilityGroupSortInput,
+  b: FacilityGroupSortInput,
+  options: {
+    sortMode: FacilitySortMode;
+    userLocation: UserLocation | null;
+    isFavorite: (facilityId: string) => boolean;
+    prioritizeHappeningNow: boolean;
+    isHappeningNow: (session: Session) => boolean;
+  }
+): number {
+  const {
+    sortMode,
+    userLocation,
+    isFavorite,
+    prioritizeHappeningNow,
+    isHappeningNow,
+  } = options;
+
+  const facilityA = a.facility;
+  const facilityB = b.facility;
+  const isFavA = facilityA?.facility_id
+    ? isFavorite(facilityA.facility_id)
+    : false;
+  const isFavB = facilityB?.facility_id
+    ? isFavorite(facilityB.facility_id)
+    : false;
+
+  // Nearest mode: strict ascending numeric distance — no other overrides
+  if (sortMode === "distance" && userLocation) {
+    const distA = facilityDistanceKm(facilityA, userLocation, a.distance);
+    const distB = facilityDistanceKm(facilityB, userLocation, b.distance);
+    if (distA === undefined) return 1;
+    if (distB === undefined) return -1;
+    return distA - distB;
+  }
+
+  // Happening-now boost only when user enabled that filter (never in nearest mode)
+  if (prioritizeHappeningNow) {
+    const hasA = flatSessions(a.sessions).some(isHappeningNow);
+    const hasB = flatSessions(b.sessions).some(isHappeningNow);
+    if (hasA && !hasB) return -1;
+    if (!hasA && hasB) return 1;
+  }
+
+  if (sortMode === "favorites" && userLocation) {
+    if (isFavA && !isFavB) return -1;
+    if (!isFavA && isFavB) return 1;
+    const distA = facilityDistanceKm(facilityA, userLocation, a.distance);
+    const distB = facilityDistanceKm(facilityB, userLocation, b.distance);
+    if (distA === undefined) return 1;
+    if (distB === undefined) return -1;
+    return distA - distB;
+  }
+
+  if (userLocation) {
+    if (isFavA && !isFavB) return -1;
+    if (!isFavA && isFavB) return 1;
+    const distA = facilityDistanceKm(facilityA, userLocation, a.distance);
+    const distB = facilityDistanceKm(facilityB, userLocation, b.distance);
+    if (distA === undefined) return 1;
+    if (distB === undefined) return -1;
+    return distA - distB;
+  }
+
+  if (isFavA && !isFavB) return -1;
+  if (!isFavA && isFavB) return 1;
+  return (facilityA?.name || "").localeCompare(facilityB?.name || "");
+}

--- a/apps/web/src/lib/poolType.ts
+++ b/apps/web/src/lib/poolType.ts
@@ -1,0 +1,34 @@
+import type { PoolTypeFilter } from "./api";
+import type { Facility } from "../types";
+
+export function poolFlags(
+  facility: Facility | undefined | null
+): { hasIndoor: boolean; hasOutdoor: boolean } {
+  if (!facility) {
+    return { hasIndoor: false, hasOutdoor: false };
+  }
+  if (facility.has_indoor !== undefined || facility.has_outdoor !== undefined) {
+    return {
+      hasIndoor: facility.has_indoor ?? false,
+      hasOutdoor: facility.has_outdoor ?? false,
+    };
+  }
+  return { hasIndoor: facility.is_indoor ?? false, hasOutdoor: !(facility.is_indoor ?? true) };
+}
+
+export function poolTypeLabel(facility: Facility | undefined | null): string {
+  const { hasIndoor, hasOutdoor } = poolFlags(facility);
+  if (hasIndoor && hasOutdoor) return "Indoor & outdoor";
+  if (hasOutdoor) return "Outdoor";
+  return "Indoor";
+}
+
+export function matchesPoolTypeFilter(
+  facility: Facility | undefined | null,
+  poolType: PoolTypeFilter
+): boolean {
+  if (poolType === "all") return true;
+  const { hasIndoor, hasOutdoor } = poolFlags(facility);
+  if (poolType === "indoor") return hasIndoor;
+  return hasOutdoor;
+}

--- a/apps/web/src/pages/MapView.tsx
+++ b/apps/web/src/pages/MapView.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MapContainer, TileLayer, Marker, CircleMarker, useMap } from "react-leaflet";
 import { DivIcon, LatLngBounds, Map as LeafletMap } from "leaflet";
-import { facilityApi, getApiErrorMessage, type PoolTypeFilter } from "../lib/api";
+import { usePoolTypeFilter } from "@/hooks/usePoolTypeFilter";
+import { facilityApi, getApiErrorMessage } from "../lib/api";
+import { poolFlags } from "../lib/poolType";
+import { PoolTypeFilterControl } from "../components/PoolTypeFilterControl";
 import {
   formatTimeRange,
   formatDate,
@@ -25,34 +28,13 @@ import {
   X,
   Info,
   Sun,
-  Building2,
 } from "lucide-react";
 import { useDarkMode } from "../contexts/useDarkMode";
 import type { Facility } from "../types";
 
 const TORONTO_CENTER: [number, number] = [43.6532, -79.3832];
 
-const POOL_TYPE_OPTIONS: {
-  value: PoolTypeFilter;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-}[] = [
-  { value: "all", label: "All", icon: MapPin },
-  { value: "indoor", label: "Indoor", icon: Building2 },
-  { value: "outdoor", label: "Outdoor", icon: Sun },
-];
-
 const OUTDOOR_MARKER_STROKE = "#f59e0b";
-
-function poolFlags(facility: Facility): { hasIndoor: boolean; hasOutdoor: boolean } {
-  if (facility.has_indoor !== undefined || facility.has_outdoor !== undefined) {
-    return {
-      hasIndoor: facility.has_indoor ?? false,
-      hasOutdoor: facility.has_outdoor ?? false,
-    };
-  }
-  return { hasIndoor: facility.is_indoor, hasOutdoor: !facility.is_indoor };
-}
 const PANEL_TOP_MARGIN = 64;
 const PANEL_GAP = 16;
 const PANEL_WIDTH = 300;
@@ -186,52 +168,6 @@ function fitToUserAndFacilities(
 
 
 // ─── Legend ──────────────────────────────────────────────────────────────────
-
-function PoolTypeFilterControl({
-  value,
-  onChange,
-}: {
-  value: PoolTypeFilter;
-  onChange: (next: PoolTypeFilter) => void;
-}) {
-  return (
-    <div
-      data-testid="map-pool-type-filter"
-      className="pointer-events-auto flex flex-col gap-1.5"
-    >
-      <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 px-1 hidden sm:block">
-        Outdoor pools open for summer
-      </p>
-      <div
-        role="group"
-        aria-label="Pool type filter"
-        className="flex bg-white dark:bg-gray-800 rounded-full shadow-md border border-gray-200 dark:border-gray-700 p-1"
-      >
-        {POOL_TYPE_OPTIONS.map(({ value: option, label, icon: Icon }) => {
-          const active = value === option;
-          return (
-            <button
-              key={option}
-              type="button"
-              data-testid={`pool-type-${option}`}
-              onClick={() => onChange(option)}
-              className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
-                active
-                  ? option === "outdoor"
-                    ? "bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-200"
-                    : "bg-primary-100 dark:bg-primary-900/50 text-primary-800 dark:text-primary-200"
-                  : "text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
-              }`}
-            >
-              <Icon className="w-3.5 h-3.5" />
-              {label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 function MapLegend() {
   const [open, setOpen] = useState(false);
@@ -503,7 +439,7 @@ export default function MapView() {
   const [searchQuery, setSearchQuery] = useState("");
   const [highlightedFacilityId, setHighlightedFacilityId] = useState<string | null>(null);
   const [showSearch, setShowSearch] = useState(false);
-  const [poolType, setPoolType] = useState<PoolTypeFilter>("all");
+  const [poolType, setPoolType] = usePoolTypeFilter();
   const [panelAnchor, setPanelAnchor] = useState<{ x: number; y: number } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const mapRef = useRef<LeafletMap | null>(null);
@@ -853,7 +789,12 @@ export default function MapView() {
 
       {/* ── Bottom-left: pool type filter ───────────────────────────── */}
       <div className="absolute bottom-4 left-3 z-[1000] pointer-events-none max-w-[calc(100%-6rem)]">
-        <PoolTypeFilterControl value={poolType} onChange={setPoolType} />
+        <PoolTypeFilterControl
+          value={poolType}
+          onChange={setPoolType}
+          className="pointer-events-auto"
+          label="Pool type"
+        />
       </div>
 
       {/* ── Bottom-right: FABs (locate + legend) ────────────────────── */}

--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { usePoolTypeFilter } from "@/hooks/usePoolTypeFilter";
 import { scheduleApi, getApiErrorMessage } from "../lib/api";
+import { matchesPoolTypeFilter, poolFlags, poolTypeLabel } from "../lib/poolType";
+import { compareFacilityGroups, facilityDistanceKm } from "../lib/facilitySort";
+import { PoolTypeFilterControl } from "@/components/PoolTypeFilterControl";
 import {
   formatDate,
   formatTimeRange,
@@ -30,6 +34,7 @@ import {
   Share2,
   Calendar as CalendarIcon,
   Check,
+  Sun,
 } from "lucide-react";
 import type { SwimType, Session } from "../types";
 
@@ -167,25 +172,6 @@ const ShareButton = ({ session }: { session: Session }) => {
   );
 };
 
-// Calendar Button Component
-const CalendarButton = ({ session }: { session: Session }) => {
-  const handleAddToCalendar = () => {
-    const url = generateCalendarUrl(session);
-    window.open(url, '_blank', 'noopener,noreferrer');
-  };
-
-  return (
-    <button
-      onClick={handleAddToCalendar}
-      className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-all duration-200 hover:scale-105"
-      aria-label="Add to calendar"
-      title="Add to Google Calendar"
-    >
-      <CalendarIcon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-    </button>
-  );
-};
-
 // Free Entry Badge Component
 const FreeEntryBadge = () => {
   return (
@@ -212,8 +198,8 @@ const compareSessions = (
 
   // Sort by distance mode: pure distance sorting (no favorites priority)
   if (sortMode === "distance" && userLocation) {
-    const distA = a.distance;
-    const distB = b.distance;
+    const distA = facilityDistanceKm(a.facility, userLocation, a.distance);
+    const distB = facilityDistanceKm(b.facility, userLocation, b.distance);
     if (distA === undefined) return 1;
     if (distB === undefined) return -1;
     return distA - distB;
@@ -226,8 +212,8 @@ const compareSessions = (
     if (!isFavA && isFavB) return 1;
 
     // Within favorites and non-favorites, sort by distance
-    const distA = a.distance;
-    const distB = b.distance;
+    const distA = facilityDistanceKm(a.facility, userLocation, a.distance);
+    const distB = facilityDistanceKm(b.facility, userLocation, b.distance);
     if (distA === undefined) return 1;
     if (distB === undefined) return -1;
     return distA - distB;
@@ -240,8 +226,8 @@ const compareSessions = (
     if (!isFavA && isFavB) return 1;
 
     // Within favorites and non-favorites, sort by distance
-    const distA = a.distance;
-    const distB = b.distance;
+    const distA = facilityDistanceKm(a.facility, userLocation, a.distance);
+    const distB = facilityDistanceKm(b.facility, userLocation, b.distance);
     if (distA === undefined) return 1;
     if (distB === undefined) return -1;
     return distA - distB;
@@ -267,6 +253,7 @@ export default function ScheduleView() {
   const [swimType, setSwimType] = useState<SwimType | "ALL">("LANE_SWIM");
   const [ageFilter, setAgeFilter] = useState<AgeFilter>("all");
   const [showFreeOnly, setShowFreeOnly] = useState(false);
+  const [poolType, setPoolType] = usePoolTypeFilter();
   // Time-of-day filter: default is full day [5am, 11pm]
   const TIME_MIN = 5 * 60;
   const TIME_MAX = 23 * 60;
@@ -372,6 +359,9 @@ export default function ScheduleView() {
     if (showFreeOnly) {
       filtered = filtered.filter((s) => s.facility?.is_free_entry === true);
     }
+    if (poolType !== "all") {
+      filtered = filtered.filter((s) => matchesPoolTypeFilter(s.facility, poolType));
+    }
     if (!isTimeDefault) {
       filtered = filtered.filter((s) => {
         const [sh, sm] = s.start_time.split(":").map(Number);
@@ -383,7 +373,7 @@ export default function ScheduleView() {
       });
     }
     return filtered;
-  }, [allSessions, swimType, showFreeOnly, isTimeDefault, timeStart, timeEnd]);
+  }, [allSessions, swimType, showFreeOnly, poolType, isTimeDefault, timeStart, timeEnd]);
 
   // Handle toggling favorites
   const handleToggleFavorite = async (facilityId: string | undefined) => {
@@ -610,69 +600,20 @@ export default function ScheduleView() {
 
   // Sort facilities: by distance (if enabled) or favorites first then by location
   const sortedFacilityEntries = Object.entries(sessionsByFacilityAndDay || {});
-  sortedFacilityEntries.sort((a, b) => {
-    const facilityA = a[1].facility;
-    const facilityB = b[1].facility;
-    const isFavA = facilityA?.facility_id
-      ? isFavorite(facilityA.facility_id)
-      : false;
-    const isFavB = facilityB?.facility_id
-      ? isFavorite(facilityB.facility_id)
-      : false;
-    
-    // Prioritize facilities with sessions happening now
-    const allSessionsA = Object.values(a[1].sessions).flat();
-    const allSessionsB = Object.values(b[1].sessions).flat();
-    const hasHappeningNowA = allSessionsA.some(isHappeningNow);
-    const hasHappeningNowB = allSessionsB.some(isHappeningNow);
-    if (hasHappeningNowA && !hasHappeningNowB) return -1;
-    if (!hasHappeningNowA && hasHappeningNowB) return 1;
-
-    // Sort by distance mode: pure distance sorting (no favorites priority)
-    if (sortMode === "distance" && userLocation) {
-      const distA = a[1].distance;
-      const distB = b[1].distance;
-      if (distA === undefined) return 1;
-      if (distB === undefined) return -1;
-      return distA - distB;
-    }
-
-    // Favorites first mode: favorites first (sorted by location), then non-favorites (sorted by location)
-    if (sortMode === "favorites" && userLocation) {
-      // Favorites come first
-      if (isFavA && !isFavB) return -1;
-      if (!isFavA && isFavB) return 1;
-
-      // Within favorites and non-favorites, sort by distance
-      const distA = a[1].distance;
-      const distB = b[1].distance;
-      if (distA === undefined) return 1;
-      if (distB === undefined) return -1;
-      return distA - distB;
-    }
-
-    // Default when location is available: favorites first, then by distance
-    if (userLocation) {
-      // Favorites come first
-      if (isFavA && !isFavB) return -1;
-      if (!isFavA && isFavB) return 1;
-
-      // Within favorites and non-favorites, sort by distance
-      const distA = a[1].distance;
-      const distB = b[1].distance;
-      if (distA === undefined) return 1;
-      if (distB === undefined) return -1;
-      return distA - distB;
-    }
-
-    // Fallback when no location: favorites first, then alphabetical order
-    if (isFavA && !isFavB) return -1;
-    if (!isFavA && isFavB) return 1;
-
-    const nameA = facilityA?.name || "";
-    const nameB = facilityB?.name || "";
-    return nameA.localeCompare(nameB);
-  });
+  const facilitySortOptions = {
+    sortMode,
+    userLocation,
+    isFavorite,
+    prioritizeHappeningNow,
+    isHappeningNow,
+  };
+  sortedFacilityEntries.sort((a, b) =>
+    compareFacilityGroups(
+      { facility: a[1].facility, distance: a[1].distance, sessions: a[1].sessions },
+      { facility: b[1].facility, distance: b[1].distance, sessions: b[1].sessions },
+      facilitySortOptions
+    )
+  );
 
   const weekdays = [
     "Sunday",
@@ -979,6 +920,15 @@ export default function ScheduleView() {
                 </span>
               </button>
 
+              {/* Pool type: indoor / outdoor */}
+              <PoolTypeFilterControl
+                value={poolType}
+                onChange={setPoolType}
+                testId="schedule-pool-type-filter"
+                showHint={false}
+                label="Pool type"
+              />
+
               {/* View Mode Toggle - Hidden on mobile since list view is optimal */}
               <div className="hidden md:flex gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5 ml-auto">
                 <button
@@ -1142,38 +1092,14 @@ export default function ScheduleView() {
               }, {} as Record<string, { facility: typeof dateSessions[0]["facility"]; sessions: typeof dateSessions; distance?: number }>);
 
               // Sort facilities by the same criteria
-              const sortedFacilities = Object.entries(sessionsByFacility).sort(([, a], [, b]) => {
-                const isFavA = a.facility?.facility_id ? isFavorite(a.facility.facility_id) : false;
-                const isFavB = b.facility?.facility_id ? isFavorite(b.facility.facility_id) : false;
-                
-                // Prioritize facilities with sessions happening now
-                const hasHappeningNowA = a.sessions.some(isHappeningNow);
-                const hasHappeningNowB = b.sessions.some(isHappeningNow);
-                if (hasHappeningNowA && !hasHappeningNowB) return -1;
-                if (!hasHappeningNowA && hasHappeningNowB) return 1;
-
-                if (sortMode === "distance" && userLocation) {
-                  const distA = a.distance;
-                  const distB = b.distance;
-                  if (distA === undefined) return 1;
-                  if (distB === undefined) return -1;
-                  return distA - distB;
-                }
-
-                if (sortMode === "favorites" && userLocation) {
-                  if (isFavA && !isFavB) return -1;
-                  if (!isFavA && isFavB) return 1;
-                  const distA = a.distance;
-                  const distB = b.distance;
-                  if (distA === undefined) return 1;
-                  if (distB === undefined) return -1;
-                  return distA - distB;
-                }
-
-                if (isFavA && !isFavB) return -1;
-                if (!isFavA && isFavB) return 1;
-                return (a.facility?.name || "").localeCompare(b.facility?.name || "");
-              });
+              const sortedFacilities = Object.entries(sessionsByFacility).sort(
+                ([, a], [, b]) =>
+                  compareFacilityGroups(
+                    { facility: a.facility, distance: a.distance, sessions: a.sessions },
+                    { facility: b.facility, distance: b.distance, sessions: b.sessions },
+                    facilitySortOptions
+                  )
+              );
 
               return (
                 <div
@@ -1188,16 +1114,19 @@ export default function ScheduleView() {
                     </p>
                   </div>
 
-                  {/* Sessions grouped by facility on mobile */}
-                  {isMobile ? (
-                    <div className="p-3 space-y-4">
-                      {sortedFacilities.map(([facilityId, data]) => (
+                  {/* Sessions grouped by facility */}
+                  <div className="p-3 md:p-4 space-y-4">
+                    {sortedFacilities.map(([facilityId, data]) => {
+                      const { hasOutdoor } = poolFlags(data.facility);
+                      const label = poolTypeLabel(data.facility);
+
+                      return (
                         <div
                           key={facilityId}
                           className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden"
                         >
                           {/* Facility Header */}
-                          <div className="p-3 bg-primary-50 dark:bg-gray-700 border-b border-primary-100 dark:border-gray-600">
+                          <div className="p-3 md:p-4 bg-primary-50 dark:bg-gray-700 border-b border-primary-100 dark:border-gray-600">
                             <div className="flex items-start gap-2">
                               <button
                                 onClick={() =>
@@ -1211,7 +1140,7 @@ export default function ScheduleView() {
                                 }
                               >
                                 <Star
-                                  className={`w-5 h-5 ${
+                                  className={`w-5 h-5 md:w-6 md:h-6 ${
                                     favorites.has(data.facility?.facility_id || "")
                                       ? "fill-yellow-400 text-yellow-400"
                                       : "text-gray-400 dark:text-gray-500 hover:text-yellow-400"
@@ -1219,30 +1148,42 @@ export default function ScheduleView() {
                                 />
                               </button>
                               <div className="flex-1 min-w-0">
-                                <h3 className="font-bold text-gray-900 dark:text-white text-sm leading-tight">
-                                  {data.facility?.website ? (
-                                    <a
-                                      href={data.facility.website}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="hover:text-primary-600 dark:hover:text-primary-400 hover:underline transition-colors"
-                                    >
-                                      {data.facility?.name}
-                                    </a>
-                                  ) : (
-                                    data.facility?.name
-                                  )}
-                                  {data.facility?.is_free_entry && (
-                                    <FreeEntryBadge />
-                                  )}
-                                </h3>
+                                <div className="flex items-center gap-2 flex-wrap">
+                                  <h3 className="font-bold text-gray-900 dark:text-white text-sm md:text-base leading-tight">
+                                    {data.facility?.website ? (
+                                      <a
+                                        href={data.facility.website}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="hover:text-primary-600 dark:hover:text-primary-400 hover:underline transition-colors"
+                                      >
+                                        {data.facility?.name}
+                                      </a>
+                                    ) : (
+                                      data.facility?.name
+                                    )}
+                                    {data.facility?.is_free_entry && (
+                                      <FreeEntryBadge />
+                                    )}
+                                  </h3>
+                                  <span
+                                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                                      hasOutdoor
+                                        ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300"
+                                        : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+                                    }`}
+                                  >
+                                    {hasOutdoor && <Sun className="w-3 h-3" />}
+                                    {label}
+                                  </span>
+                                </div>
                                 <div className="flex items-center gap-2 mt-1 flex-wrap">
                                   {data.distance !== undefined && (
                                     <button
                                       onClick={() =>
                                         setMapsModalAddress(data.facility?.address || "")
                                       }
-                                      className="inline-flex items-center gap-1 text-xs font-semibold text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300"
+                                      className="inline-flex items-center gap-1 text-xs md:text-sm font-semibold text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300"
                                     >
                                       <Navigation className="w-3 h-3" />
                                       {formatDistance(data.distance)}
@@ -1255,7 +1196,7 @@ export default function ScheduleView() {
                                       )}`}
                                       target="_blank"
                                       rel="noopener noreferrer"
-                                      className="text-xs text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 truncate max-w-[200px]"
+                                      className="text-xs md:text-sm text-gray-600 dark:text-gray-300 hover:text-primary-600 dark:hover:text-primary-400 truncate max-w-[200px] md:max-w-none"
                                     >
                                       {data.facility.address}
                                     </a>
@@ -1266,7 +1207,7 @@ export default function ScheduleView() {
                           </div>
 
                           {/* Time Slots Grid - sorted with happening now first */}
-                          <div className="p-2 grid grid-cols-2 gap-2">
+                          <div className="p-2 md:p-3 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
                             {[...data.sessions].sort((a, b) => {
                               const aHappening = isHappeningNow(a);
                               const bHappening = isHappeningNow(b);
@@ -1278,13 +1219,13 @@ export default function ScheduleView() {
                               return (
                                 <div
                                   key={session.id}
-                                  className={`p-2.5 rounded-lg transition-all ${
+                                  className={`p-2.5 md:p-3 rounded-lg transition-all ${
                                     happeningNow
                                       ? "bg-gradient-to-br from-yellow-100 to-amber-100 dark:from-yellow-900/40 dark:to-amber-900/40 ring-2 ring-yellow-400 dark:ring-yellow-600"
                                       : "bg-gray-50 dark:bg-gray-700/50"
                                   }`}
                                 >
-                                  <div className={`text-sm font-bold mb-1 ${
+                                  <div className={`text-sm md:text-base font-bold mb-1 ${
                                     happeningNow
                                       ? "text-yellow-900 dark:text-yellow-100"
                                       : "text-primary-600 dark:text-primary-400"
@@ -1293,13 +1234,16 @@ export default function ScheduleView() {
                                   </div>
                                   <div className="flex items-center justify-between gap-1">
                                     <span
-                                      className={`px-2 py-0.5 rounded-md text-[10px] font-bold ${getSwimTypeColor(
+                                      className={`px-2 py-0.5 rounded-md text-[10px] md:text-xs font-bold ${getSwimTypeColor(
                                         session.swim_type
                                       )}`}
                                     >
                                       {getSwimTypeLabelAbbreviated(session.swim_type)}
                                     </span>
                                     <div className="flex items-center gap-0.5">
+                                      <div className="hidden md:block">
+                                        <ShareButton session={session} />
+                                      </div>
                                       <button
                                         onClick={() => {
                                           const url = generateCalendarUrl(session);
@@ -1313,7 +1257,7 @@ export default function ScheduleView() {
                                     </div>
                                   </div>
                                   {session.notes && (
-                                    <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-1 line-clamp-1">
+                                    <p className="text-[10px] md:text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-1 md:line-clamp-2">
                                       {session.notes}
                                     </p>
                                   )}
@@ -1322,141 +1266,9 @@ export default function ScheduleView() {
                             })}
                           </div>
                         </div>
-                      ))}
-                    </div>
-                  ) : (
-                    /* Desktop list view - original layout */
-                    <div className="divide-y divide-gray-200 dark:divide-gray-700">
-                      {dateSessions.map((session) => {
-                        const happeningNow = isHappeningNow(session);
-
-                        return (
-                          <div
-                            key={session.id}
-                            className={`p-4 md:p-6 rounded-xl border-2 transition-all duration-200 ${
-                              happeningNow
-                                ? "bg-gradient-to-br from-yellow-50 to-amber-50 dark:from-yellow-900/30 dark:to-amber-900/30 border-yellow-400 dark:border-yellow-600 shadow-lg ring-2 ring-yellow-400/50"
-                                : "bg-white/80 dark:bg-gray-800/80 border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md"
-                            }`}
-                          >
-                            <div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
-                              {/* Facility */}
-                              <div className="flex-1 flex items-start gap-2">
-                                <button
-                                  onClick={() =>
-                                    handleToggleFavorite(
-                                      session.facility?.facility_id
-                                    )
-                                  }
-                                  className="flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center hover:scale-110 transition-transform duration-200"
-                                  aria-label={
-                                    favorites.has(
-                                      session.facility?.facility_id || ""
-                                    )
-                                      ? "Remove from favorites"
-                                      : "Add to favorites"
-                                  }
-                                  title={
-                                    favorites.has(
-                                      session.facility?.facility_id || ""
-                                    )
-                                      ? "Remove from favorites"
-                                      : "Add to favorites"
-                                  }
-                                >
-                                  <Star
-                                    className={`w-6 h-6 ${
-                                      favorites.has(
-                                        session.facility?.facility_id || ""
-                                      )
-                                        ? "fill-yellow-400 text-yellow-400"
-                                        : "text-gray-300 dark:text-gray-600 hover:text-yellow-400 dark:hover:text-yellow-400"
-                                    }`}
-                                  />
-                                </button>
-                                <div className="flex-1">
-                                  {/* Time - Most important info, shown prominently */}
-                                  <div className="text-xl font-bold text-primary-600 dark:text-primary-400 mb-2">
-                                    {formatTimeRange(session.start_time, session.end_time)}
-                                  </div>
-                                  <h3 className="font-bold text-gray-900 dark:text-gray-100 mb-1 text-base">
-                                    {session.facility?.website ? (
-                                      <a
-                                        href={session.facility.website}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="hover:text-primary-600 dark:hover:text-primary-400 hover:underline transition-colors"
-                                      >
-                                        {session.facility.name}
-                                      </a>
-                                    ) : (
-                                      session.facility?.name
-                                    )}
-                                    {session.facility?.is_free_entry && (
-                                      <span className="ml-2 inline-block"><FreeEntryBadge /></span>
-                                    )}
-                                    {session.distance !== undefined &&
-                                      session.facility?.address && (
-                                        <button
-                                          onClick={() =>
-                                            setMapsModalAddress(
-                                              session.facility!.address!
-                                            )
-                                          }
-                                          className="ml-2 text-sm font-semibold text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:underline cursor-pointer transition-colors"
-                                          title="Open in maps"
-                                        >
-                                          ({formatDistance(session.distance)})
-                                        </button>
-                                      )}
-                                  </h3>
-                                  {session.facility?.address && (
-                                    <p className="text-sm text-gray-600 dark:text-gray-400 flex items-start gap-1">
-                                      <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                                      <a
-                                        href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                                          session.facility.address
-                                        )}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="hover:text-primary-600 dark:hover:text-primary-400 hover:underline transition-colors"
-                                      >
-                                        {session.facility.address}
-                                      </a>
-                                    </p>
-                                  )}
-                                </div>
-                              </div>
-
-                              {/* Type + Actions */}
-                              <div className="flex-shrink-0 flex flex-col sm:flex-row items-end sm:items-center gap-2">
-                                <span
-                                  className={`px-4 py-2 rounded-xl text-xs font-bold ${getSwimTypeColor(
-                                    session.swim_type
-                                  )} shadow-sm`}
-                                >
-                                  {getSwimTypeLabel(session.swim_type)}
-                                </span>
-                                <div className="flex items-center gap-1">
-                                  <ShareButton session={session} />
-                                  <CalendarButton session={session} />
-                                </div>
-                              </div>
-                            </div>
-
-                            {/* Notes */}
-                            {session.notes && (
-                              <div className="w-full mt-3 md:col-span-full">
-                                <p className="text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">
-                                  {session.notes}
-                                </p>
-                              </div>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
+                      );
+                    })}
+                  </div>
                 </div>
               );
             })}

--- a/apps/web/src/tests/mobile-ux.spec.ts
+++ b/apps/web/src/tests/mobile-ux.spec.ts
@@ -313,26 +313,28 @@ test.describe("Mobile UX - Session Times Visibility", () => {
     }
   });
 
-  test("session cards should show time before facility name", async ({ page }) => {
+  test("session cards should show times within facility groups", async ({ page }) => {
     await page.goto("/schedule");
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(2000);
 
-    // Find session cards in list view
-    const sessionCards = page.locator('[class*="rounded-xl"][class*="border-2"]');
-    const cardCount = await sessionCards.count();
+    // Facility-grouped cards in list view
+    const facilityCards = page.locator(
+      '[class*="rounded-xl"][class*="border-gray"]'
+    );
+    const cardCount = await facilityCards.count();
 
     if (cardCount > 0) {
-      const firstCard = sessionCards.first();
-      
+      const firstCard = facilityCards.first();
+
       // Get the text content of the card
       const cardText = await firstCard.textContent();
-      
+
       // Time pattern should appear in the card
       const timePattern = /\d{1,2}:\d{2}\s*(AM|PM)/i;
       expect(cardText).toMatch(timePattern);
-      
-      console.log(`✓ Session card contains time information`);
+
+      console.log(`✓ Facility card contains time information`);
     }
   });
 });

--- a/apps/web/src/tests/schedule-pool-filter.spec.ts
+++ b/apps/web/src/tests/schedule-pool-filter.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Schedule pool type filter (indoor / outdoor / all).
+ * Client-side filter on /schedule — parity with map page control.
+ */
+
+test.describe("Schedule pool type filter", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/schedule");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByTestId("schedule-pool-type-filter")).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test("outdoor filter highlights and reduces visible facilities", async ({
+    page,
+  }) => {
+    // Switch to list view on desktop so facility cards are visible
+    const listBtn = page.getByRole("button", { name: /List View/i });
+    if (await listBtn.isVisible()) {
+      await listBtn.click();
+    }
+
+    await page.waitForTimeout(1500);
+
+    const facilityCards = page.locator(
+      '[class*="rounded-xl"][class*="border-gray"]'
+    );
+    const allCount = await facilityCards.count();
+
+    await page.getByTestId("pool-type-outdoor").click();
+    await expect(page.getByTestId("pool-type-outdoor")).toHaveClass(/bg-amber/);
+
+    await page.waitForTimeout(500);
+
+    const outdoorCount = await facilityCards.count();
+
+    // Outdoor filter should show outdoor pool type badges
+    const outdoorBadges = page.getByText("Outdoor", { exact: true });
+    if ((await outdoorBadges.count()) > 0) {
+      await expect(outdoorBadges.first()).toBeVisible();
+    }
+
+    // Filter should not increase result count
+    if (allCount > 0) {
+      expect(outdoorCount).toBeLessThanOrEqual(allCount);
+    }
+  });
+
+  test("indoor filter highlights and indoor-only sites hide outdoor badges", async ({
+    page,
+  }) => {
+    await page.getByTestId("pool-type-indoor").click();
+    await expect(page.getByTestId("pool-type-indoor")).toHaveClass(/bg-primary/);
+
+    // Pure outdoor-only badges should not appear when indoor filter is active
+    const outdoorOnlyBadges = page.locator(
+      'span:has-text("Outdoor"):not(:has-text("Indoor"))'
+    );
+    await expect(outdoorOnlyBadges).toHaveCount(0);
+  });
+
+  test("all filter restores full schedule", async ({ page }) => {
+    await page.getByTestId("pool-type-outdoor").click();
+    await page.waitForTimeout(300);
+
+    const outdoorCount = await page
+      .locator('[class*="rounded-xl"][class*="border-gray"]')
+      .count();
+
+    await page.getByTestId("pool-type-all").click();
+    await expect(page.getByTestId("pool-type-all")).toHaveClass(/bg-primary/);
+    await page.waitForTimeout(300);
+
+    const allCount = await page
+      .locator('[class*="rounded-xl"][class*="border-gray"]')
+      .count();
+
+    if (outdoorCount > 0) {
+      expect(allCount).toBeGreaterThanOrEqual(outdoorCount);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add **All / Indoor / Outdoor** pool-type filter to `/schedule` (shared `PoolTypeFilterControl` with map; selection persisted in `localStorage`)
- **Grouped list view** on desktop: one card per community centre with multi-column time grid
- **Fix nearest sort** (#254): happening-now no longer overrides distance when Nearest mode is active
- Fix `.gitignore` (`lib/` → `/lib/`) so `apps/web/src/lib/poolType.ts` and `facilitySort.ts` are tracked in git

## Test plan
- [x] `npm run type-check`
- [x] `vitest` — `facilitySort.test.ts` (3 tests)
- [x] Playwright — `schedule-pool-filter.spec.ts`, `map-panel.spec.ts` pool type filter
- [ ] Manual: `/schedule` — Pool type toolbar; List view grouped by facility
- [ ] Manual: `/map` — bottom-left pool filter; selection syncs with schedule

Closes #254

Made with [Cursor](https://cursor.com)