### PR TITLE
fix(web): outdoor schedule includes recreational swim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Outdoor schedule shows recreational swim** — with the Outdoor pool filter active, the default Lane chip now includes **Lane & Rec** (recreational/leisure sessions were hidden by the lane-only filter).
 - **Schedule nearest sort order** — facilities with “happening now” sessions no longer jump ahead of closer pools when Nearest sort is active; distance sort is strictly numeric ascending. Happening-now boost applies only when that filter is explicitly enabled (and not in Nearest mode).
 - **Map no longer auto-zooms back when filters change** ([#232]): `MapController` ran `fitBounds` on every change to its deps, which included inline-derived `validFacilities` — a fresh array reference on every render. So every keystroke in search, every pool-type toggle, every favorite click, every unrelated re-render re-fit the map and yanked the user's manual zoom back. Now the initial fit happens exactly once via a `useRef` guard; the Locate / Recenter FAB explicitly re-fits via a new top-level helper `fitToUserAndFacilities(map, ...)`; the four derived facility arrays (`facilitiesWithDistance`, `sortedFacilities`, `visibleFacilities`, `validFacilities`) are memoized so dependent effects don't fire on spurious renders. As a side fix, the panel-position effect now listens on Leaflet's `moveend` (not `move`) so the panel doesn't briefly render with negative pixel coords during an animated `panBy`.
 

--- a/apps/web/src/lib/swimTypeFilter.test.ts
+++ b/apps/web/src/lib/swimTypeFilter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getSwimTypeFilterLabel, matchesSwimTypeFilter } from "./swimTypeFilter";
+
+describe("matchesSwimTypeFilter", () => {
+  it("includes recreational when outdoor and lane chip selected", () => {
+    expect(matchesSwimTypeFilter("RECREATIONAL", "LANE_SWIM", "outdoor")).toBe(
+      true
+    );
+    expect(matchesSwimTypeFilter("LANE_SWIM", "LANE_SWIM", "outdoor")).toBe(
+      true
+    );
+  });
+
+  it("excludes recreational for indoor lane-only filter", () => {
+    expect(matchesSwimTypeFilter("RECREATIONAL", "LANE_SWIM", "indoor")).toBe(
+      false
+    );
+    expect(matchesSwimTypeFilter("LANE_SWIM", "LANE_SWIM", "indoor")).toBe(
+      true
+    );
+  });
+
+  it("shows only recreational when that chip is selected", () => {
+    expect(matchesSwimTypeFilter("RECREATIONAL", "RECREATIONAL", "outdoor")).toBe(
+      true
+    );
+    expect(matchesSwimTypeFilter("LANE_SWIM", "RECREATIONAL", "outdoor")).toBe(
+      false
+    );
+  });
+});
+
+describe("getSwimTypeFilterLabel", () => {
+  it("labels outdoor lane default as Lane & Rec", () => {
+    expect(getSwimTypeFilterLabel("LANE_SWIM", "outdoor")).toBe("Lane & Rec");
+    expect(getSwimTypeFilterLabel("LANE_SWIM", "indoor")).toBe("Lane Swim");
+  });
+});

--- a/apps/web/src/lib/swimTypeFilter.ts
+++ b/apps/web/src/lib/swimTypeFilter.ts
@@ -1,0 +1,43 @@
+import type { PoolTypeFilter } from "./api";
+import type { SwimType } from "../types";
+
+/** Drop-in types commonly offered at outdoor pools (City of Toronto). */
+export const OUTDOOR_DROP_IN_SWIM_TYPES: readonly SwimType[] = [
+  "LANE_SWIM",
+  "RECREATIONAL",
+];
+
+export function getSwimTypeFilterLabel(
+  swimType: SwimType | "ALL",
+  poolType: PoolTypeFilter
+): string {
+  if (swimType === "ALL") return "All Types";
+  if (swimType === "LANE_SWIM" && poolType === "outdoor") {
+    return "Lane & Rec";
+  }
+  const labels: Record<string, string> = {
+    LANE_SWIM: "Lane Swim",
+    RECREATIONAL: "Recreational Swim",
+    ADULT_SWIM: "Adult Swim",
+    SENIOR_SWIM: "Senior Swim",
+    AQUATIC_FITNESS: "Aquatic Fitness",
+    OTHER: "Other",
+  };
+  return labels[swimType] || swimType;
+}
+
+/**
+ * Schedule swim-type filter. Outdoor pools default to lane + recreational
+ * when the Lane Swim chip is selected (same default as indoor-only lane view).
+ */
+export function matchesSwimTypeFilter(
+  sessionSwimType: string,
+  swimType: SwimType | "ALL",
+  poolType: PoolTypeFilter
+): boolean {
+  if (swimType === "ALL") return true;
+  if (poolType === "outdoor" && swimType === "LANE_SWIM") {
+    return OUTDOOR_DROP_IN_SWIM_TYPES.includes(sessionSwimType as SwimType);
+  }
+  return sessionSwimType === swimType;
+}

--- a/apps/web/src/pages/ScheduleView.tsx
+++ b/apps/web/src/pages/ScheduleView.tsx
@@ -4,6 +4,10 @@ import { usePoolTypeFilter } from "@/hooks/usePoolTypeFilter";
 import { scheduleApi, getApiErrorMessage } from "../lib/api";
 import { matchesPoolTypeFilter, poolFlags, poolTypeLabel } from "../lib/poolType";
 import { compareFacilityGroups, facilityDistanceKm } from "../lib/facilitySort";
+import {
+  getSwimTypeFilterLabel,
+  matchesSwimTypeFilter,
+} from "../lib/swimTypeFilter";
 import { PoolTypeFilterControl } from "@/components/PoolTypeFilterControl";
 import {
   formatDate,
@@ -354,7 +358,9 @@ export default function ScheduleView() {
     if (!allSessions) return undefined;
     let filtered = allSessions;
     if (swimType !== "ALL") {
-      filtered = filtered.filter((s) => s.swim_type === swimType);
+      filtered = filtered.filter((s) =>
+        matchesSwimTypeFilter(s.swim_type, swimType, poolType)
+      );
     }
     if (showFreeOnly) {
       filtered = filtered.filter((s) => s.facility?.is_free_entry === true);
@@ -1039,7 +1045,9 @@ export default function ScheduleView() {
                         : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
                     }`}
                   >
-                    {type === "ALL" ? "All Types" : getSwimTypeLabel(type)}
+                    {type === "ALL"
+                      ? "All Types"
+                      : getSwimTypeFilterLabel(type as SwimType | "ALL", poolType)}
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- When **Outdoor** pool filter is active, the default Lane chip now shows **Lane & Rec** (lane + recreational/leisure sessions)
- Indoor schedule unchanged — Lane chip still filters to lane swim only

## Test plan
- [x] `vitest` — `swimTypeFilter.test.ts` (4 tests)
- [ ] Mobile: `/schedule` → Outdoor → verify leisure swim times appear alongside lane swim

Made with [Cursor](https://cursor.com)