### PR TITLE
feat(api): admin user endpoints and nav tab order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Admin user endpoints** — `GET /admin/users` (email list + signup dates) and `GET /admin/users/stats` (total, signups this week/today) protected by `ADMIN_TOKEN`. Prometheus gauges `swimto_db_users_signups_week` and `swimto_db_users_signups_today` for Grafana (Applications/SwimTO dashboard).
+- **Nav tab order** — header tabs reordered to Home → Schedule → Map → About.
+
 - **Indoor/outdoor pool filter on schedule page**: All / Indoor / Outdoor segmented control on `/schedule`, matching the map page. Client-side filter uses `has_indoor` / `has_outdoor` on each session's facility. Shared `PoolTypeFilterControl` component extracted from `MapView`; selection persisted in `localStorage` so schedule and map stay in sync.
 - **Grouped list view on desktop schedule**: List view now groups sessions by community center on all screen sizes (same pattern as mobile since v0.7.5). One facility card shows multiple time slots in a responsive 2–4 column grid; pool-type badge on facility header; share action per slot on desktop.
 

--- a/apps/api/app/deps/admin.py
+++ b/apps/api/app/deps/admin.py
@@ -1,0 +1,24 @@
+"""Admin API authentication."""
+
+from fastapi import Depends, Header, HTTPException
+
+from app.config import settings
+
+
+def verify_admin_token(authorization: str = Header(None)) -> str:
+    """Verify ``Authorization: Bearer <ADMIN_TOKEN>``."""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header missing")
+
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    token = parts[1]
+    if token != settings.admin_token:
+        raise HTTPException(status_code=403, detail="Invalid token")
+
+    return token
+
+
+AdminToken = Depends(verify_admin_token)

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -13,13 +13,18 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
-from sqlalchemy import func
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
 from app.database import SessionLocal, engine
-from app.models import Base, User
-from app.routes import facilities, schedule, update, health, auth, favorites, preferences
+from app.models import Base
+from app.user_metrics import (
+    count_signups_since,
+    count_users,
+    toronto_day_start,
+    toronto_week_start,
+)
+from app.routes import facilities, schedule, update, health, auth, favorites, preferences, admin
 
 # Initialize Sentry if DSN is configured
 sentry_dsn = os.getenv("SENTRY_DSN")
@@ -118,6 +123,14 @@ swimto_db_users_total = Gauge(
     "swimto_db_users_total",
     "Registered users in the SwimTO database (refreshed periodically)",
 )
+swimto_db_users_signups_week = Gauge(
+    "swimto_db_users_signups_week",
+    "New user signups since Monday 00:00 America/Toronto (refreshed periodically)",
+)
+swimto_db_users_signups_today = Gauge(
+    "swimto_db_users_signups_today",
+    "New user signups since today 00:00 America/Toronto (refreshed periodically)",
+)
 
 
 async def _refresh_business_metrics_loop() -> None:
@@ -125,8 +138,16 @@ async def _refresh_business_metrics_loop() -> None:
         try:
             db = SessionLocal()
             try:
-                n = db.query(func.count(User.id)).scalar()
-                swimto_db_users_total.set(float(n or 0))
+                total = count_users(db)
+                week_start = toronto_week_start()
+                day_start = toronto_day_start()
+                swimto_db_users_total.set(float(total))
+                swimto_db_users_signups_week.set(
+                    float(count_signups_since(db, week_start))
+                )
+                swimto_db_users_signups_today.set(
+                    float(count_signups_since(db, day_start))
+                )
             finally:
                 db.close()
         except Exception as e:
@@ -135,6 +156,7 @@ async def _refresh_business_metrics_loop() -> None:
 
 
 # Include routers
+app.include_router(admin.router, tags=["admin"])
 app.include_router(health.router, tags=["health"])
 app.include_router(auth.router, tags=["auth"])
 app.include_router(favorites.router, tags=["favorites"])

--- a/apps/api/app/routes/admin.py
+++ b/apps/api/app/routes/admin.py
@@ -1,0 +1,54 @@
+"""Admin endpoints (Bearer ADMIN_TOKEN)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.deps.admin import verify_admin_token
+from app.models import User
+from app.schemas import AdminUserListResponse, AdminUserStatsResponse, AdminUserSummary
+from app.user_metrics import (
+    count_signups_since,
+    count_users,
+    toronto_day_start,
+    toronto_week_start,
+)
+
+router = APIRouter(prefix="/admin")
+
+
+@router.get("/users/stats", response_model=AdminUserStatsResponse, tags=["admin"])
+async def get_user_stats(
+    _: str = Depends(verify_admin_token),
+    db: Session = Depends(get_db),
+):
+    """Registered-user counts for growth tracking."""
+    week_start = toronto_week_start()
+    day_start = toronto_day_start()
+    return AdminUserStatsResponse(
+        total_users=count_users(db),
+        signups_this_week=count_signups_since(db, week_start),
+        signups_today=count_signups_since(db, day_start),
+        week_start_utc=week_start,
+    )
+
+
+@router.get("/users", response_model=AdminUserListResponse, tags=["admin"])
+async def list_users(
+    _: str = Depends(verify_admin_token),
+    db: Session = Depends(get_db),
+):
+    """List registered users (email + signup time) for outreach."""
+    users = db.query(User).order_by(User.created_at.desc()).all()
+    return AdminUserListResponse(
+        total=len(users),
+        users=[
+            AdminUserSummary(
+                id=u.id,
+                email=u.email,
+                name=u.name,
+                created_at=u.created_at,
+            )
+            for u in users
+        ],
+    )

--- a/apps/api/app/routes/update.py
+++ b/apps/api/app/routes/update.py
@@ -2,32 +2,15 @@
 import subprocess
 import sys
 from pathlib import Path
-from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from loguru import logger
 
 from app.database import get_db
+from app.deps.admin import verify_admin_token
 from app.schemas import UpdateResponse
-from app.config import settings
 
 router = APIRouter()
-
-
-def verify_admin_token(authorization: str = Header(None)):
-    """Verify admin token."""
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Authorization header missing")
-    
-    # Expected format: "Bearer <token>"
-    parts = authorization.split()
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        raise HTTPException(status_code=401, detail="Invalid authorization header")
-    
-    token = parts[1]
-    if token != settings.admin_token:
-        raise HTTPException(status_code=403, detail="Invalid token")
-    
-    return token
 
 
 @router.post("/", response_model=UpdateResponse)

--- a/apps/api/app/schemas.py
+++ b/apps/api/app/schemas.py
@@ -188,6 +188,28 @@ class UserPreferencesResponse(UserPreferencesBase):
         from_attributes = True
 
 
+class AdminUserSummary(BaseModel):
+    """Registered user row for admin list."""
+    id: int
+    email: str
+    name: Optional[str] = None
+    created_at: datetime
+
+
+class AdminUserListResponse(BaseModel):
+    """Admin list of registered users."""
+    total: int
+    users: List[AdminUserSummary]
+
+
+class AdminUserStatsResponse(BaseModel):
+    """Signup KPIs (Toronto-local week)."""
+    total_users: int
+    signups_this_week: int
+    signups_today: int
+    week_start_utc: datetime
+
+
 # Resolve forward references for Pydantic v2
 FacilityWithSessions.model_rebuild()
 

--- a/apps/api/app/user_metrics.py
+++ b/apps/api/app/user_metrics.py
@@ -1,0 +1,51 @@
+"""User signup metrics helpers (Toronto-local week boundaries)."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models import User
+
+TORONTO = ZoneInfo("America/Toronto")
+
+
+def _toronto_midnight_as_utc_naive(when: datetime) -> datetime:
+    """Convert a Toronto-local datetime to naive UTC for DB comparison."""
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=TORONTO)
+    return when.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def toronto_week_start(now: Optional[datetime] = None) -> datetime:
+    """Monday 00:00 America/Toronto for the week containing ``now``."""
+    local = (now or datetime.now(TORONTO)).astimezone(TORONTO)
+    monday = local.date() - timedelta(days=local.weekday())
+    start_local = datetime(
+        monday.year, monday.month, monday.day, tzinfo=TORONTO
+    )
+    return _toronto_midnight_as_utc_naive(start_local)
+
+
+def toronto_day_start(now: Optional[datetime] = None) -> datetime:
+    """Today 00:00 America/Toronto."""
+    local = (now or datetime.now(TORONTO)).astimezone(TORONTO)
+    start_local = datetime(
+        local.year, local.month, local.day, tzinfo=TORONTO
+    )
+    return _toronto_midnight_as_utc_naive(start_local)
+
+
+def count_users(db: Session) -> int:
+    return int(db.query(func.count(User.id)).scalar() or 0)
+
+
+def count_signups_since(db: Session, since_utc_naive: datetime) -> int:
+    return int(
+        db.query(func.count(User.id))
+        .filter(User.created_at >= since_utc_naive)
+        .scalar()
+        or 0
+    )

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -1,0 +1,67 @@
+"""Tests for admin user endpoints."""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import User
+
+ADMIN_HEADERS = {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture(autouse=True)
+def admin_token_env(monkeypatch):
+    monkeypatch.setenv("ADMIN_TOKEN", "test-token")
+
+
+def _add_user(db, email: str, days_ago: int = 0) -> User:
+    created = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days_ago)
+    user = User(
+        email=email,
+        name="Test User",
+        google_id=f"google-{email}",
+        created_at=created,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_admin_users_requires_token(client):
+    response = client.get("/admin/users")
+    assert response.status_code == 401
+
+
+def test_admin_users_rejects_bad_token(client):
+    response = client.get(
+        "/admin/users",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 403
+
+
+def test_admin_users_lists_registered_users(client, db):
+    _add_user(db, "alpha@example.com", days_ago=10)
+    _add_user(db, "beta@example.com", days_ago=1)
+
+    response = client.get("/admin/users", headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    emails = {u["email"] for u in data["users"]}
+    assert emails == {"alpha@example.com", "beta@example.com"}
+
+
+def test_admin_user_stats(client, db):
+    _add_user(db, "old@example.com", days_ago=30)
+    _add_user(db, "recent@example.com", days_ago=0)
+
+    response = client.get("/admin/users/stats", headers=ADMIN_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_users"] == 2
+    assert data["signups_today"] >= 1
+    assert "signups_this_week" in data
+    assert "week_start_utc" in data

--- a/apps/api/tests/test_user_metrics.py
+++ b/apps/api/tests/test_user_metrics.py
@@ -1,0 +1,22 @@
+"""Tests for user signup metric helpers."""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from app.user_metrics import toronto_day_start, toronto_week_start
+
+TORONTO = ZoneInfo("America/Toronto")
+
+
+def test_toronto_week_start_is_monday_midnight():
+    # Wednesday 2026-06-18 15:00 Toronto
+    when = datetime(2026, 6, 18, 15, 0, tzinfo=TORONTO)
+    start = toronto_week_start(when)
+    # Monday 2026-06-16 04:00 UTC (EDT = UTC-4)
+    assert start == datetime(2026, 6, 16, 4, 0)
+
+
+def test_toronto_day_start_is_local_midnight():
+    when = datetime(2026, 6, 18, 15, 0, tzinfo=TORONTO)
+    start = toronto_day_start(when)
+    assert start == datetime(2026, 6, 18, 4, 0)

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -77,13 +77,13 @@ export default function Layout() {
                   <Home className="w-5 h-5" />
                   <span className="hidden sm:inline">Home</span>
                 </NavLink>
-                <NavLink to="/map" className={navLinkClass}>
-                  <Map className="w-5 h-5" />
-                  <span className="hidden sm:inline">Map</span>
-                </NavLink>
                 <NavLink to="/schedule" className={navLinkClass}>
                   <Calendar className="w-5 h-5" />
                   <span className="hidden sm:inline">Schedule</span>
+                </NavLink>
+                <NavLink to="/map" className={navLinkClass}>
+                  <Map className="w-5 h-5" />
+                  <span className="hidden sm:inline">Map</span>
                 </NavLink>
                 <NavLink to="/about" className={navLinkClass}>
                   <Info className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- `GET /admin/users` — list registered emails + signup dates (Bearer `ADMIN_TOKEN`)
- `GET /admin/users/stats` — total users, signups this week/today (Toronto timezone)
- Prometheus gauges `swimto_db_users_signups_week` and `swimto_db_users_signups_today`
- Header nav order: **Home → Schedule → Map → About**

Companion Grafana PR: pi-fleet#TBD

## Usage (prod)
```bash
# Stats
curl -s https://api.swimto.app/admin/users/stats \
  -H "Authorization: Bearer $ADMIN_TOKEN" | jq

# Email list
curl -s https://api.swimto.app/admin/users \
  -H "Authorization: Bearer $ADMIN_TOKEN" | jq '.users[] | {email, created_at}'
```

## Test plan
- [ ] CI pytest (admin + user_metrics)
- [ ] `npm run type-check`
- [ ] Manual: nav order on mobile + desktop
- [ ] After deploy: admin endpoints with Vault `ADMIN_TOKEN`
- [ ] Merge pi-fleet Grafana PR for signup panels


Made with [Cursor](https://cursor.com)