### PR TITLE
chore(ci): trigger build on dev branch pushes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,7 +2,7 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "apps/api/**"
       - "apps/web/**"


### PR DESCRIPTION
## Summary

Adds `dev` to the branch trigger so pushes to the `dev` branch run CI and emit `dev-<timestamp>-<sha>` image tags. Requires [github-workflows #28](https://github.com/raolivei/github-workflows/pull/28) to be merged first.

## Flow after this

- Push to `dev` → CI → `dev-<ts>-<sha>` tags in ghcr → `swimto-dev` auto-deploys
- Push to `main` → CI → `build-<ts>-<sha>` + semver (when VERSION bumped) → prod deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)